### PR TITLE
Gladly Destination

### DIFF
--- a/packages/destination-actions/src/destinations/gladly/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-gladly destination: conversationItem action - all fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-gladly destination: conversationItem action - required fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-gladly destination: conversationItem action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authoriz
+    ation": Array [
+      "Basic N3hUd2NxUSlLQHpnVGY6N3hUd2NxUSlLQHpnVGY=",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gladly destination: customer action - all fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-gladly destination: customer action - required fields 1`] = `""`;
+
+exports[`Testing snapshot for actions-gladly destination: customer action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Basic KmRdVDJHN3h2XmJedToqZF1UMkc3eHZeYl51",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gladly/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -7,8 +7,7 @@ exports[`Testing snapshot for actions-gladly destination: conversationItem actio
 exports[`Testing snapshot for actions-gladly destination: conversationItem action - required fields 2`] = `
 Headers {
   Symbol(map): Object {
-    "authoriz
-    ation": Array [
+    "authorization": Array [
       "Basic N3hUd2NxUSlLQHpnVGY6N3hUd2NxUSlLQHpnVGY=",
     ],
     "user-agent": Array [

--- a/packages/destination-actions/src/destinations/gladly/__tests__/gladly-mappings.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/gladly-mappings.test.ts
@@ -1,0 +1,187 @@
+import { mappings } from '../gladly-mappings'
+import { GenericPayload } from '../gladly-types'
+
+fdescribe('Gladly Mappings', () => {
+  describe('generateConversationItemJSON', () => {
+    const email = 'test@gladly.com'
+    const phone = '2345678901'
+    const title = 'Test Event'
+    const body = 'test event body'
+    it('formats using email when both email and phone are passed', () => {
+      const request: GenericPayload = {
+        email,
+        phone,
+        title,
+        body
+      }
+      const response = mappings.conversationItem(request)
+
+      expect(response).toStrictEqual({
+        customer: {
+          emailAddress: email
+        },
+        content: {
+          type: 'CUSTOMER_ACTIVITY',
+          title,
+          body,
+          activityType: 'EMAIL',
+          sourceName: 'Segment'
+        }
+      })
+    })
+    it('formats the message correctly with email', () => {
+      const request: GenericPayload = {
+        email,
+        title,
+        body
+      }
+      const response = mappings.conversationItem(request)
+
+      expect(response).toStrictEqual({
+        customer: {
+          emailAddress: email
+        },
+        content: {
+          type: 'CUSTOMER_ACTIVITY',
+          title,
+          body,
+          activityType: 'EMAIL',
+          sourceName: 'Segment'
+        }
+      })
+    })
+    it('formats the message correctly with phone', () => {
+      const request: GenericPayload = {
+        phone,
+        title,
+        body
+      }
+      const response = mappings.conversationItem(request)
+
+      expect(response).toStrictEqual({
+        customer: {
+          mobilePhone: phone
+        },
+        content: {
+          type: 'CUSTOMER_ACTIVITY',
+          title,
+          body,
+          activityType: 'SMS',
+          sourceName: 'Segment'
+        }
+      })
+    })
+  })
+  fdescribe('generateCreateCustomerJSON', () => {
+    const name = 'Joe Bob'
+    const email = 'test@gladly.com'
+    const phone = '2345678901'
+    const address = `100 Test St. New York City NY US 10001`
+    const externalCustomerId = '123'
+    const customAttributes = {
+      attribute: 'test'
+    }
+
+    it('returns customer with all fields formatted', () => {
+      const request: GenericPayload = {
+        name,
+        email,
+        phone,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      const response = mappings.createCustomer(request)
+      expect(response).toStrictEqual({
+        name,
+        address,
+        emails: [
+          {
+            original: email,
+            primary: true
+          }
+        ],
+        phones: [
+          {
+            original: phone,
+            primary: true
+          }
+        ],
+        externalCustomerId,
+        customAttributes
+      })
+    })
+    it('returns customer with formatted email and no phone', () => {
+      const request: GenericPayload = {
+        name,
+        email,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      const response = mappings.createCustomer(request)
+      expect(response).toStrictEqual({
+        name,
+        address,
+        emails: [
+          {
+            original: email,
+            primary: true
+          }
+        ],
+        phones: [],
+        externalCustomerId,
+        customAttributes
+      })
+    })
+    it('returns customer with formatted phone and no email', () => {
+      const request: GenericPayload = {
+        name,
+        phone,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      const response = mappings.createCustomer(request)
+      expect(response).toStrictEqual({
+        name,
+        address,
+        emails: [],
+        phones: [
+          {
+            original: phone,
+            primary: true
+          }
+        ],
+        externalCustomerId,
+        customAttributes
+      })
+    })
+    it('returns customer with just external customer id', () => {
+      const request: GenericPayload = {
+        externalCustomerId
+      }
+      const response = mappings.createCustomer(request)
+      expect(response).toStrictEqual({
+        name: '',
+        address: '',
+        emails: [],
+        phones: [],
+        externalCustomerId,
+        customAttributes: {}
+      })
+    })
+  })
+
+  describe('generateUpdateCustomerJSON', () => {
+    // const name = 'Joe Bob'
+    // const email = 'test@gladly.com'
+    // const phone = '2345678901'
+    // const address = `100 Test St. New York City NY US 10001`
+    // const externalCustomerId = '123'
+    // const customAttributes = {
+    //   attribute: 'test'
+    // }
+    describe('email', () => {})
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/__tests__/gladly-mappings.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/gladly-mappings.test.ts
@@ -1,5 +1,5 @@
 import { mappings } from '../gladly-mappings'
-import { GenericPayload } from '../gladly-types'
+import { GenericPayload } from '../gladly-shared-types'
 
 fdescribe('Gladly Mappings', () => {
   describe('generateConversationItemJSON', () => {

--- a/packages/destination-actions/src/destinations/gladly/__tests__/gladly-mappings.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/gladly-mappings.test.ts
@@ -1,12 +1,13 @@
 import { mappings } from '../gladly-mappings'
-import { GenericPayload } from '../gladly-shared-types'
+import { Customer, GenericPayload } from '../gladly-shared-types'
 
-fdescribe('Gladly Mappings', () => {
+describe('Gladly Mappings', () => {
   describe('generateConversationItemJSON', () => {
     const email = 'test@gladly.com'
     const phone = '2345678901'
     const title = 'Test Event'
     const body = 'test event body'
+
     it('formats using email when both email and phone are passed', () => {
       const request: GenericPayload = {
         email,
@@ -29,6 +30,7 @@ fdescribe('Gladly Mappings', () => {
         }
       })
     })
+
     it('formats the message correctly with email', () => {
       const request: GenericPayload = {
         email,
@@ -50,6 +52,7 @@ fdescribe('Gladly Mappings', () => {
         }
       })
     })
+
     it('formats the message correctly with phone', () => {
       const request: GenericPayload = {
         phone,
@@ -72,7 +75,8 @@ fdescribe('Gladly Mappings', () => {
       })
     })
   })
-  fdescribe('generateCreateCustomerJSON', () => {
+
+  describe('generateCreateCustomerJSON', () => {
     const name = 'Joe Bob'
     const email = 'test@gladly.com'
     const phone = '2345678901'
@@ -111,6 +115,7 @@ fdescribe('Gladly Mappings', () => {
         customAttributes
       })
     })
+
     it('returns customer with formatted email and no phone', () => {
       const request: GenericPayload = {
         name,
@@ -134,6 +139,7 @@ fdescribe('Gladly Mappings', () => {
         customAttributes
       })
     })
+
     it('returns customer with formatted phone and no email', () => {
       const request: GenericPayload = {
         name,
@@ -157,6 +163,7 @@ fdescribe('Gladly Mappings', () => {
         customAttributes
       })
     })
+
     it('returns customer with just external customer id', () => {
       const request: GenericPayload = {
         externalCustomerId
@@ -174,14 +181,131 @@ fdescribe('Gladly Mappings', () => {
   })
 
   describe('generateUpdateCustomerJSON', () => {
-    // const name = 'Joe Bob'
-    // const email = 'test@gladly.com'
-    // const phone = '2345678901'
-    // const address = `100 Test St. New York City NY US 10001`
-    // const externalCustomerId = '123'
-    // const customAttributes = {
-    //   attribute: 'test'
-    // }
-    describe('email', () => {})
+    const name = 'Joe Bob'
+    const email = 'test@gladly.com'
+    const phone = '2345678901'
+    const address = `100 Test St. New York City NY US 10001`
+    const externalCustomerId = '123'
+    const customAttributes = {
+      attribute: 'test'
+    }
+
+    describe('when customer has data to update', () => {
+      const customer: Customer = {
+        id: '123',
+        name: 'Jane Smith',
+        emails: [{ original: 'janesmith@gladly.com' }],
+        phones: [{ original: '4567879012' }],
+        address: '333 Example Ave. Houston TX US 77002',
+        externalCustomerId: '456',
+        customAttributes: {
+          test: 'example'
+        },
+        createdAt: '07-10-22'
+      }
+
+      it('updates customer name', () => {
+        const request: GenericPayload = {
+          name
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.name).toBe(name)
+      })
+
+      it('updates customer email', () => {
+        const request: GenericPayload = {
+          email
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.emails).toStrictEqual([{ original: 'janesmith@gladly.com' }, { original: email }])
+      })
+
+      it('updates customer phone', () => {
+        const request: GenericPayload = {
+          phone
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.phones).toStrictEqual([{ original: '4567879012' }, { original: phone }])
+      })
+
+      it('updates customer address', () => {
+        const request: GenericPayload = {
+          address
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.address).toBe(address)
+      })
+
+      it('updates customer external customer id', () => {
+        const request: GenericPayload = {
+          externalCustomerId
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.externalCustomerId).toBe(externalCustomerId)
+      })
+
+      it('updates customer custom attributes', () => {
+        const request: GenericPayload = {
+          customAttributes
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.customAttributes).toStrictEqual({ test: 'example', attribute: 'test' })
+      })
+    })
+
+    describe('when customer does not have data to update', () => {
+      const customer: Customer = {
+        id: '123',
+        createdAt: '07-10-22'
+      }
+
+      it('updates customer name', () => {
+        const request: GenericPayload = {
+          name
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.name).toBe(name)
+      })
+
+      it('updates customer email', () => {
+        const request: GenericPayload = {
+          email
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.emails).toStrictEqual([{ original: email, primary: true }])
+      })
+
+      it('updates customer phone', () => {
+        const request: GenericPayload = {
+          phone
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.phones).toStrictEqual([{ original: phone, primary: true }])
+      })
+
+      it('updates customer address', () => {
+        const request: GenericPayload = {
+          address
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.address).toBe(address)
+      })
+
+      it('updates customer external customer id', () => {
+        const request: GenericPayload = {
+          externalCustomerId
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.externalCustomerId).toBe(externalCustomerId)
+      })
+
+      it('updates customer custom attributes', () => {
+        const request: GenericPayload = {
+          customAttributes
+        }
+        const response = mappings.updateCustomer(customer, request)
+        expect(response.customAttributes).toStrictEqual({ attribute: 'test' })
+      })
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/gladly/__tests__/gladly-operations.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/gladly-operations.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { Gladly, API_VERSION } from '../gladly-operations'
 import { Settings } from '../generated-types'
-import { GenericPayload, Customer } from '../gladly-types'
+import { GenericPayload, Customer } from '../gladly-shared-types'
 import { HTTPError, IntegrationError } from '@segment/actions-core'
 import createRequestClient from '../../../../../core/src/create-request-client'
 

--- a/packages/destination-actions/src/destinations/gladly/__tests__/gladly-operations.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/gladly-operations.test.ts
@@ -1,0 +1,392 @@
+import nock from 'nock'
+import { Gladly, API_VERSION } from '../gladly-operations'
+import { Settings } from '../generated-types'
+import { GenericPayload, Customer } from '../gladly-types'
+import { HTTPError, IntegrationError } from '@segment/actions-core'
+import createRequestClient from '../../../../../core/src/create-request-client'
+
+describe('Gladly', () => {
+  const settings: Settings = {
+    username: 'user',
+    password: 'password',
+    orgName: 'test-org',
+    isSandbox: false
+  }
+  const request = createRequestClient()
+
+  const subject = new Gladly(settings, request)
+  const baseUrl = `https://${settings.orgName}.us-1.gladly.com${API_VERSION}`
+
+  describe('createConversationItem', () => {
+    const customerId = '123'
+
+    const email = 'test@gladly.com'
+    const phone = '2345678901'
+    const title = 'Test Event'
+    const body = 'test body for event'
+
+    it('returns a successful response with email and phone', async () => {
+      const payload: GenericPayload = {
+        email,
+        phone,
+        title,
+        body
+      }
+      nock(baseUrl).post(`/customers/${customerId}/conversation-items`).reply(200, {})
+
+      const response = await subject.createConversationItem(customerId, payload)
+
+      expect(response.url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items"`
+      )
+      expect(response.status).toMatchInlineSnapshot(`200`)
+      expect(response.data).toStrictEqual({})
+    })
+    it('returns a successful response with only email', async () => {
+      const payload: GenericPayload = {
+        email,
+        title,
+        body
+      }
+      nock(baseUrl).post(`/customers/${customerId}/conversation-items`).reply(200, {})
+
+      const response = await subject.createConversationItem(customerId, payload)
+
+      expect(response.url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items"`
+      )
+      expect(response.status).toMatchInlineSnapshot(`200`)
+      expect(response.data).toStrictEqual({})
+    })
+    it('returns a successful response with only phone', async () => {
+      const payload: GenericPayload = {
+        phone,
+        title,
+        body
+      }
+      nock(baseUrl).post(`/customers/${customerId}/conversation-items`).reply(200, {})
+
+      const response = await subject.createConversationItem(customerId, payload)
+
+      expect(response.url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items"`
+      )
+      expect(response.status).toMatchInlineSnapshot(`200`)
+      expect(response.data).toStrictEqual({})
+    })
+    it('throws integration error when email and phone are not included', async () => {
+      const payload: GenericPayload = {
+        title,
+        body
+      }
+
+      let response, error
+      try {
+        response = await subject.createConversationItem(customerId, payload)
+      } catch (e) {
+        error = e
+      }
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(IntegrationError)
+    })
+    it('throws http error when status code is not 2xx', async () => {
+      const payload: GenericPayload = {
+        email,
+        title,
+        body
+      }
+      nock(baseUrl).post(`/customers/${customerId}/conversation-items`).reply(400, { error: 'error' })
+
+      let response, error
+      try {
+        response = await subject.createConversationItem(customerId, payload)
+      } catch (e) {
+        error = e
+      }
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(HTTPError)
+    })
+  })
+  describe('createCustomer', () => {
+    const name = 'Joe Bob'
+    const email = 'test@gladly.com'
+    const phone = '2345678901'
+    const address = '123 Test St. New York City NY US 10001'
+    const externalCustomerId = '123'
+    const customAttributes = {
+      tier: 'vip'
+    }
+
+    it('returns a successful response with email and phone', async () => {
+      const payload: GenericPayload = {
+        name,
+        email,
+        phone,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      nock(baseUrl).post(`/customer-profiles`).reply(201, {})
+
+      const response = await subject.createCustomer(payload)
+
+      expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles"`)
+      expect(response.status).toMatchInlineSnapshot(`201`)
+      expect(response.data).toStrictEqual({})
+    })
+
+    it('returns a successful response with only email', async () => {
+      const payload: GenericPayload = {
+        name,
+        email,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      nock(baseUrl).post(`/customer-profiles`).reply(201, {})
+
+      const response = await subject.createCustomer(payload)
+
+      expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles"`)
+      expect(response.status).toMatchInlineSnapshot(`201`)
+      expect(response.data).toStrictEqual({})
+    })
+
+    it('returns a successful response with only phone', async () => {
+      const payload: GenericPayload = {
+        name,
+        phone,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      nock(baseUrl).post(`/customer-profiles`).reply(201, {})
+
+      const response = await subject.createCustomer(payload)
+
+      expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles"`)
+      expect(response.status).toMatchInlineSnapshot(`201`)
+      expect(response.data).toStrictEqual({})
+    })
+
+    it('throws integration error when email and phone are not included', async () => {
+      const payload: GenericPayload = {
+        name,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+
+      let response, error
+      try {
+        response = await subject.createCustomer(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(IntegrationError)
+    })
+
+    it('throws http error when status code is not 2xx', async () => {
+      const payload: GenericPayload = {
+        name,
+        email,
+        phone,
+        address,
+        externalCustomerId,
+        customAttributes
+      }
+      nock(baseUrl).post(`/customer-profiles`).reply(400, { error: 'error' })
+
+      let response, error
+      try {
+        response = await subject.createCustomer(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(HTTPError)
+    })
+  })
+  describe('findCustomer', () => {
+    const email = 'test@gladly.com'
+    const phone = '+12345678901'
+    it('returns a successful response with email and phone', async () => {
+      const payload: GenericPayload = {
+        email,
+        phone
+      }
+      nock(baseUrl)
+        .get(`/customer-profiles`)
+        .query({ email })
+        .reply(200, [
+          {
+            id: '123'
+          }
+        ])
+
+      const response = await subject.findCustomer(payload)
+
+      expect(response.url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?email=test%40gladly.com"`
+      )
+      expect(response.status).toMatchInlineSnapshot(`200`)
+      expect(response.data).toStrictEqual([{ id: '123' }])
+    })
+
+    it('returns a successful response with only email', async () => {
+      const payload: GenericPayload = {
+        email
+      }
+      nock(baseUrl)
+        .get(`/customer-profiles`)
+        .query({ email })
+        .reply(200, [
+          {
+            id: '123'
+          }
+        ])
+
+      const response = await subject.findCustomer(payload)
+
+      expect(response.url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?email=test%40gladly.com"`
+      )
+      expect(response.status).toMatchInlineSnapshot(`200`)
+      expect(response.data).toStrictEqual([{ id: '123' }])
+    })
+
+    it('returns a successful response with only phone', async () => {
+      const payload: GenericPayload = {
+        phone
+      }
+      nock(baseUrl)
+        .get(`/customer-profiles`)
+        .query({ phoneNumber: phone })
+        .reply(200, [
+          {
+            id: '123'
+          }
+        ])
+
+      const response = await subject.findCustomer(payload)
+
+      expect(response.url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?phoneNumber=%2B12345678901"`
+      )
+      expect(response.status).toMatchInlineSnapshot(`200`)
+      expect(response.data).toStrictEqual([{ id: '123' }])
+    })
+
+    it('throws an integration error when email and phone are not included', async () => {
+      const payload: GenericPayload = {}
+
+      let response, error
+      try {
+        response = await subject.findCustomer(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(IntegrationError)
+    })
+    it('throws a http error when status is not 2xx', async () => {
+      const payload: GenericPayload = {
+        email
+      }
+      nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400, { error: 'error' })
+
+      let response, error
+      try {
+        response = await subject.findCustomer(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(HTTPError)
+    })
+  })
+  describe('updateCustomer', () => {
+    const email = 'test1@gladly.com'
+    const phone = '2345678902'
+    const customerId = '123'
+
+    const customer: Customer = {
+      id: customerId,
+      createdAt: '07-11-2022'
+    }
+    it('returns a successful response with email and phone', async () => {
+      const payload: GenericPayload = {
+        email,
+        phone
+      }
+      nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(204, {})
+
+      const response = await subject.updateCustomer(customer, payload)
+
+      expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles/123"`)
+      expect(response.status).toMatchInlineSnapshot(`204`)
+      expect(response.data).toStrictEqual({})
+    })
+    it('returns a successful response with only email', async () => {
+      const payload: GenericPayload = {
+        email
+      }
+      nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(204, {})
+
+      const response = await subject.updateCustomer(customer, payload)
+
+      expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles/123"`)
+      expect(response.status).toMatchInlineSnapshot(`204`)
+      expect(response.data).toStrictEqual({})
+    })
+    it('returns a successful response with only phone', async () => {
+      const payload: GenericPayload = {
+        phone
+      }
+      nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(204, {})
+
+      const response = await subject.updateCustomer(customer, payload)
+
+      expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles/123"`)
+      expect(response.status).toMatchInlineSnapshot(`204`)
+      expect(response.data).toStrictEqual({})
+    })
+
+    it('throws an integration error when email and phone are not included', async () => {
+      const payload: GenericPayload = {}
+
+      let response, error
+      try {
+        response = await subject.updateCustomer(customer, payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(IntegrationError)
+    })
+
+    it('throws HTTP Error when status code is not 2xx', async () => {
+      const payload: GenericPayload = {
+        email,
+        phone
+      }
+      nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(400, { error: 'error' })
+
+      let response, error
+      try {
+        response = await subject.updateCustomer(customer, payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(response).not.toBeDefined()
+      expect(error).toBeInstanceOf(HTTPError)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/__tests__/gladly-operations.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/gladly-operations.test.ts
@@ -4,6 +4,8 @@ import { Gladly, API_VERSION } from '../gladly-operations'
 import { Settings } from '../generated-types'
 import { Customer } from '../gladly-shared-types'
 import { HTTPError } from '@segment/actions-core'
+import { Payload as ConversationItemPayload } from '../conversationItem/generated-types'
+import { Payload as CustomerPayload } from '../customer/generated-types'
 import createRequestClient from '../../../../../core/src/create-request-client'
 
 describe('Gladly', () => {
@@ -29,14 +31,16 @@ describe('Gladly', () => {
       const activityType = 'EMAIL'
 
       it('calls create conversation item endpoint successfully', async () => {
-        const result = await subject.createConversationItem(customerId, {
+        const request: ConversationItemPayload = {
           email,
           phone,
           title,
           body,
           activityType,
           sourceName
-        })
+        }
+        const result = await subject.createConversationItem(customerId, request)
+
         expect(subject.request).toHaveBeenCalledWith(
           'https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items',
           {
@@ -62,14 +66,15 @@ describe('Gladly', () => {
       const activityType = 'EMAIL'
 
       it('calls create conversation item endpoint successfully', async () => {
-        const result = await subject.createConversationItem(customerId, {
+        const request: ConversationItemPayload = {
           email,
-          phone: '',
           title,
           body,
           activityType,
           sourceName
-        })
+        }
+        const result = await subject.createConversationItem(customerId, request)
+
         expect(subject.request).toHaveBeenCalledWith(
           'https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items',
           {
@@ -95,14 +100,15 @@ describe('Gladly', () => {
       const activityType = 'SMS'
 
       it('calls create conversation item endpoint successfully', async () => {
-        const result = await subject.createConversationItem(customerId, {
-          email: '',
+        const request: ConversationItemPayload = {
           phone,
           title,
           body,
           activityType,
           sourceName
-        })
+        }
+        const result = await subject.createConversationItem(customerId, request)
+
         expect(subject.request).toHaveBeenCalledWith(
           'https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items',
           {
@@ -135,16 +141,17 @@ describe('Gladly', () => {
       })
 
       it('throws an http error', async () => {
+        const request: ConversationItemPayload = {
+          email,
+          phone,
+          title,
+          body,
+          activityType,
+          sourceName
+        }
         let response
         try {
-          response = await subject.createConversationItem(customerId, {
-            email,
-            phone,
-            title,
-            body,
-            activityType,
-            sourceName
-          })
+          response = await subject.createConversationItem(customerId, request)
         } catch (e) {
           response = e
         }
@@ -165,7 +172,9 @@ describe('Gladly', () => {
 
     describe('with all fields', () => {
       it('calls create customer endpoint successfully', async () => {
-        const response = await subject.createCustomer({ name, email, phone, address, customAttributes, override })
+        const request: CustomerPayload = { name, email, phone, address, customAttributes, override }
+        const response = await subject.createCustomer(request)
+
         expect(subject.request).toHaveBeenCalledWith('https://test-org.us-1.gladly.com/api/v1/customer-profiles', {
           json: {
             address,
@@ -182,21 +191,12 @@ describe('Gladly', () => {
 
     describe('with only email', () => {
       it('calls create customer endpoint successfully', async () => {
-        const response = await subject.createCustomer({
-          name: '',
-          email,
-          phone: '',
-          address: '',
-          customAttributes: {},
-          override
-        })
+        const request: CustomerPayload = { email, override }
+        const response = await subject.createCustomer(request)
+
         expect(subject.request).toHaveBeenCalledWith('https://test-org.us-1.gladly.com/api/v1/customer-profiles', {
           json: {
-            address: '',
-            customAttributes: {},
-            emails: [{ original: email, primary: false }],
-            name: '',
-            phones: []
+            emails: [{ original: email, primary: false }]
           },
           method: 'post'
         })
@@ -206,20 +206,11 @@ describe('Gladly', () => {
 
     describe('with only phone', () => {
       it('calls create customer endpoint successfully', async () => {
-        const response = await subject.createCustomer({
-          name: '',
-          email: '',
-          phone,
-          address: '',
-          customAttributes: {},
-          override
-        })
+        const request: CustomerPayload = { phone, override }
+        const response = await subject.createCustomer(request)
+
         expect(subject.request).toHaveBeenCalledWith('https://test-org.us-1.gladly.com/api/v1/customer-profiles', {
           json: {
-            address: '',
-            customAttributes: {},
-            emails: [],
-            name: '',
             phones: [{ original: phone, primary: false }]
           },
           method: 'post'
@@ -253,6 +244,7 @@ describe('Gladly', () => {
     describe('when the request is successful', () => {
       it('calls the find customer endpoint correctly', async () => {
         const response = await subject.findCustomerByEmail(email)
+
         expect(subject.request).toHaveBeenCalledWith(
           'https://test-org.us-1.gladly.com/api/v1/customer-profiles?email=test%40gladly.com',
           { method: 'get' }
@@ -285,6 +277,7 @@ describe('Gladly', () => {
     describe('when the request is successful', () => {
       it('calls the find customer endpoint correctly', async () => {
         const response = await subject.findCustomerByPhone(phone)
+
         expect(subject.request).toHaveBeenCalledWith(
           'https://test-org.us-1.gladly.com/api/v1/customer-profiles?phoneNumber=%2B12345678901',
           { method: 'get' }
@@ -312,11 +305,6 @@ describe('Gladly', () => {
   })
 
   describe('updateCustomer', () => {
-    const customer: Customer = {
-      id: '123',
-      createdAt: '07-11-2022'
-    }
-
     const name = 'Joe Bob'
     const email = 'test1@gladly.com'
     const phone = '2345678902'
@@ -327,17 +315,16 @@ describe('Gladly', () => {
 
     describe('when the request is successful', () => {
       describe('when override is true', () => {
+        const customer: Customer = {
+          id: '123',
+          createdAt: '07-11-2022'
+        }
         const override = true
 
         it('calls the update customer endpoint correctly', async () => {
-          const response = await subject.updateCustomer(customer, {
-            name,
-            email,
-            phone,
-            address,
-            customAttributes,
-            override
-          })
+          const request: CustomerPayload = { name, email, phone, address, customAttributes, override }
+          const response = await subject.updateCustomer(customer, request)
+
           expect(subject.request).toHaveBeenCalledWith(
             'https://test-org.us-1.gladly.com/api/v1/customer-profiles/123',
             {
@@ -354,10 +341,54 @@ describe('Gladly', () => {
           expect(response).not.toBeInstanceOf(Error)
         })
       })
+
+      describe('when override is false', () => {
+        const customer: Customer = {
+          id: '123',
+          name: 'Jane Doe',
+          address: '456 Happy. Ave Houston TX US 77001',
+          emails: [
+            {
+              original: 'janedoe@gladly.com',
+              primary: true
+            }
+          ],
+          phones: [
+            {
+              original: '6789012345',
+              primary: false
+            }
+          ],
+          customAttributes: {
+            tier: 'regular'
+          },
+          createdAt: '07-11-2022'
+        }
+        const override = false
+
+        it('calls the update customer endpoint correctly', async () => {
+          const request: CustomerPayload = { name, email, phone, address, customAttributes, override }
+          const response = await subject.updateCustomer(customer, request)
+
+          expect(subject.request).toHaveBeenCalledWith(
+            'https://test-org.us-1.gladly.com/api/v1/customer-profiles/123',
+            {
+              json: {},
+              method: 'patch'
+            }
+          )
+          expect(response).not.toBeInstanceOf(Error)
+        })
+      })
     })
 
     describe('when the request is unsuccessful', () => {
+      const customer: Customer = {
+        id: '123',
+        createdAt: '07-11-2022'
+      }
       const override = true
+
       beforeEach(() => {
         nock(baseUrl).patch(`/customer-profiles/${customer.id}`).reply(400, { error: 'error' })
       })
@@ -381,212 +412,4 @@ describe('Gladly', () => {
       })
     })
   })
-
-  // describe('createCustomer', () => {
-  //   const name = 'Joe Bob'
-  //   const email = 'test@gladly.com'
-  //   const phone = '2345678901'
-  //   const address = '123 Test St. New York City NY US 10001'
-  //   const customAttributes = {
-  //     tier: 'vip'
-  //   }
-
-  //   describe('with all fields', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl).post(`/customer-profiles`).reply(201, {})
-  //     })
-
-  //     it('call create customer endpoint successfully', async () => {
-  //       const response = await whenInvoked(name, email, phone, address, customAttributes)
-  //       expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles"`)
-  //       expect(response.options.headers).toMatchInlineSnapshot()
-  //       expect(response.options.data).toMatchInlineSnapshot()
-  //     })
-  //   })
-
-  //   describe('with only email', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl).post(`/customer-profiles`).reply(201, {})
-  //     })
-
-  //     it('call create customer endpoint successfully', async () => {
-  //       const response = await whenInvoked('', email, '', '', {})
-  //       expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles"`)
-  //       expect(response.options.headers).toMatchInlineSnapshot()
-  //       expect(response.options.data).toMatchInlineSnapshot()
-  //     })
-  //   })
-
-  //   describe('with only phone', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl).post(`/customer-profiles`).reply(201, {})
-  //     })
-
-  //     it('call create customer endpoint successfully', async () => {
-  //       const response = await whenInvoked('', '', phone, '', {})
-  //       expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles"`)
-  //       expect(response.options.headers).toMatchInlineSnapshot()
-  //       expect(response.options.data).toMatchInlineSnapshot()
-  //     })
-  //   })
-
-  //   describe('when the request is unsuccessful', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl).post(`/customer-profiles`).reply(400, { error: 'error' })
-  //     })
-
-  //     it('throws an http error', async () => {
-  //       const response = await whenInvoked(name, email, phone, address, customAttributes)
-  //       expect(response).toBeInstanceOf(HTTPError)
-  //     })
-  //   })
-
-  //   async function whenInvoked(name: string, email: string, phone: string, address: string, customAttributes: object) {
-  //     try {
-  //       return await subject.createCustomer(name, email, phone, address, customAttributes)
-  //     } catch (e) {
-  //       return e
-  //     }
-  //   }
-  // })
-
-  // describe('findCustomerByEmail', () => {
-  //   const email = 'test@gladly.com'
-
-  //   describe('when the request is successful', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl)
-  //         .get(`/customer-profiles`)
-  //         .query({ email })
-  //         .reply(200, [
-  //           {
-  //             id: '123'
-  //           }
-  //         ])
-  //     })
-
-  //     it('calls the find customer endpoint correctly', async () => {
-  //       const response = await whenInvoked()
-  //       expect(response.url).toMatchInlineSnapshot(
-  //         `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?email=test%40gladly.com"`
-  //       )
-  //       expect(response.options.headers).toMatchInlineSnapshot()
-  //       expect(response.options.data).toMatchInlineSnapshot()
-  //     })
-  //   })
-
-  //   describe('when the request is unsuccessful', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400, { error: 'error' })
-  //     })
-
-  //     it('throws an http error', async () => {
-  //       const response = await whenInvoked()
-  //       expect(response).toBeInstanceOf(HTTPError)
-  //     })
-  //   })
-
-  //   async function whenInvoked() {
-  //     try {
-  //       return await subject.findCustomerByEmail(email)
-  //     } catch (e) {
-  //       return e
-  //     }
-  //   }
-  // })
-
-  // describe('findCustomerByPhone', () => {
-  //   const phone = '+12345678901'
-
-  //   describe('when the request is successful', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl)
-  //         .get(`/customer-profiles`)
-  //         .query({ phoneNumber: phone })
-  //         .reply(200, [
-  //           {
-  //             id: '123'
-  //           }
-  //         ])
-  //     })
-
-  //     it('calls the find customer endpoint correctly', async () => {
-  //       const response = await whenInvoked()
-  //       expect(response.url).toMatchInlineSnapshot(
-  //         `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?phoneNumber=%2B12345678901"`
-  //       )
-  //       expect(response.options.headers).toMatchInlineSnapshot()
-  //       expect(response.options.data).toMatchInlineSnapshot()
-  //     })
-  //   })
-
-  //   describe('when the request is unsuccessful', () => {
-  //     beforeEach(() => {
-  //       nock(baseUrl).get(`/customer-profiles`).query({ phoneNumber: phone }).reply(400, { error: 'error' })
-  //     })
-
-  //     it('throws an http error', async () => {
-  //       const response = await whenInvoked()
-  //       expect(response).toBeInstanceOf(HTTPError)
-  //     })
-  //   })
-
-  //   async function whenInvoked() {
-  //     try {
-  //       return await subject.findCustomerByPhone(phone)
-  //     } catch (e) {
-  //       return e
-  //     }
-  //   }
-  // })
-
-  // describe('updateCustomer', () => {
-  //   const customer: Customer = {
-  //     id: '123',
-  //     createdAt: '07-11-2022'
-  //   }
-  //   const name = 'Joe Bob'
-  //   const address = '123 Test St. Houston, TX 77002'
-  //   const customAttributes = {
-  //     tier: 'vip'
-  //   }
-
-  //   describe('with all fields', () => {
-  //     const email = 'test1@gladly.com'
-  //     const phone = '2345678902'
-
-  //     beforeEach(() => {
-  //       nock(baseUrl).patch(`/customer-profiles/${customer.id}`).reply(204, {})
-  //     })
-
-  //     it('calls the update customer endpoint correctly', async () => {
-  //       const response = await whenInvoked(email, phone)
-  //       expect(response.url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.com/api/v1/customer-profiles/123"`)
-  //       expect(response.options.headers).toMatchInlineSnapshot()
-  //       expect(response.options.data).toMatchInlineSnapshot()
-  //     })
-  //   })
-
-  //   describe('when the request is unsuccessful', () => {
-  //     const email = 'test1@gladly.com'
-  //     const phone = '2345678902'
-
-  //     beforeEach(() => {
-  //       nock(baseUrl).patch(`/customer-profiles/${customer.id}`).reply(400, { error: 'error' })
-  //     })
-
-  //     it('throws an http error', async () => {
-  //       const response = await whenInvoked(email, phone)
-  //       expect(response).toBeInstanceOf(HTTPError)
-  //     })
-  //   })
-
-  //   async function whenInvoked(email: string, phone: string) {
-  //     try {
-  //       return await subject.updateCustomer(customer, name, email, phone, address, customAttributes)
-  //     } catch (e) {
-  //       return e
-  //     }
-  //   }
-  // })
 })

--- a/packages/destination-actions/src/destinations/gladly/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/index.test.ts
@@ -12,8 +12,7 @@ describe('Gladly', () => {
       const settings = {
         username: '<test username>',
         password: '<test password>',
-        orgName: 'test-org',
-        isSandbox: true
+        url: 'https://test-org.us-1.gladly.com'
       }
 
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/gladly/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/index.test.ts
@@ -1,0 +1,22 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Gladly', () => {
+  describe('testAuthentication', () => {
+    it('should validate authentication inputs', async () => {
+      nock('https://your.destination.endpoint').get('*').reply(200, {})
+
+      const settings = {
+        username: '<test username>',
+        password: '<test password>',
+        orgName: 'test-org',
+        isSandbox: true
+      }
+
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-gladly'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/gladly/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/snapshot.test.ts
@@ -5,6 +5,7 @@ import nock from 'nock'
 
 const testDestination = createTestIntegration(destination)
 const destinationSlug = 'actions-gladly'
+const url = 'https://test-org.us-1.gladly.com'
 
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
   for (const actionSlug in destination.actions) {
@@ -13,13 +14,21 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const action = destination.actions[actionSlug]
       const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
-      nock(/.*/).persist().get(/.*/).reply(200)
-      nock(/.*/).persist().post(/.*/).reply(200)
-      nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/)
+        .persist()
+        .get(/.*/)
+        .reply(200, [{ id: '123' }])
+      nock(/.*/)
+        .persist()
+        .post(/.*/)
+        .reply(200 || 201)
+      nock(/.*/).persist().patch(/.*/).reply(204)
 
       const event = createTestEvent({
         properties: eventData
       })
+
+      settingsData.url = url
 
       const responses = await testDestination.testAction(actionSlug, {
         event: event,
@@ -47,13 +56,21 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const action = destination.actions[actionSlug]
       const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
-      nock(/.*/).persist().get(/.*/).reply(200)
-      nock(/.*/).persist().post(/.*/).reply(200)
-      nock(/.*/).persist().put(/.*/).reply(200)
+      nock(/.*/)
+        .persist()
+        .get(/.*/)
+        .reply(200, [{ id: '123' }])
+      nock(/.*/)
+        .persist()
+        .post(/.*/)
+        .reply(200 || 201)
+      nock(/.*/).persist().patch(/.*/).reply(204)
 
       const event = createTestEvent({
         properties: eventData
       })
+
+      settingsData.url = url
 
       const responses = await testDestination.testAction(actionSlug, {
         event: event,

--- a/packages/destination-actions/src/destinations/gladly/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/__tests__/snapshot.test.ts
@@ -6,6 +6,7 @@ import nock from 'nock'
 const testDestination = createTestIntegration(destination)
 const destinationSlug = 'actions-gladly'
 const url = 'https://test-org.us-1.gladly.com'
+const email = 'test@gladly.com'
 
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
   for (const actionSlug in destination.actions) {
@@ -24,11 +25,12 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         .reply(200 || 201)
       nock(/.*/).persist().patch(/.*/).reply(204)
 
+      settingsData.url = url
+      eventData.email = email
+
       const event = createTestEvent({
         properties: eventData
       })
-
-      settingsData.url = url
 
       const responses = await testDestination.testAction(actionSlug, {
         event: event,

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Gladly's conversationItem destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for Gladly's conversationItem destination action: required fields 1`] = `""`;
+
+exports[`Testing snapshot for Gladly's conversationItem destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Basic d2gzWE0yJFVHOndoM1hNMiRVRw==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/index.test.ts
@@ -1,0 +1,178 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, IntegrationError, HTTPError } from '@segment/actions-core'
+import Destination from '../../index'
+import { API_VERSION } from '../../gladly-operations'
+
+const testDestination = createTestIntegration(Destination)
+
+const settings = {
+  username: 'example@gladly.com',
+  password: 'gladly',
+  orgName: 'test-org',
+  isSandbox: false
+}
+
+const baseUrl = `https://${settings.orgName}.us-1.gladly.com${API_VERSION}`
+
+describe('Gladly.conversationItem', () => {
+  const testCustomerId = '123'
+
+  it('creates a conversation item', async () => {
+    nock(baseUrl)
+      .get(`/customer-profiles`)
+      .query({ externalCustomerId: testCustomerId })
+      .reply(200, [
+        {
+          id: testCustomerId
+        }
+      ])
+    nock(baseUrl).post(`/customers/${testCustomerId}/conversation-items`).reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Test Event',
+      userId: testCustomerId,
+      properties: {
+        body: 'Test Body'
+      }
+    })
+
+    const responses = await testDestination.testAction('conversationItem', {
+      event,
+      settings,
+      mapping: {
+        externalCustomerId: { '@path': '$.userId' },
+        title: { '@path': '$.event' },
+        body: { '@path': '$.properties.body' }
+      }
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[1].status).toBe(200)
+  })
+  it('throws integration error when customer does not exist', async () => {
+    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId: testCustomerId }).reply(200, [])
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Test Event',
+      userId: testCustomerId,
+      properties: {
+        body: 'Test Body'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('conversationItem', {
+        event,
+        settings,
+        mapping: {
+          externalCustomerId: { '@path': '$.userId' },
+          title: { '@path': '$.event' },
+          body: { '@path': '$.properties.body' }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(IntegrationError)
+  })
+  it('throws http error when find customer response is not 200', async () => {
+    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId: testCustomerId }).reply(400, [])
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Test Event',
+      userId: testCustomerId,
+      properties: {
+        body: 'Test Body'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('conversationItem', {
+        event,
+        settings,
+        mapping: {
+          externalCustomerId: { '@path': '$.userId' },
+          title: { '@path': '$.event' },
+          body: { '@path': '$.properties.body' }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(HTTPError)
+  })
+  it('throws http error when create conversation item is not 200', async () => {
+    nock(baseUrl)
+      .get(`/customer-profiles`)
+      .query({ externalCustomerId: testCustomerId })
+      .reply(200, [
+        {
+          id: testCustomerId
+        }
+      ])
+    nock(baseUrl).post(`/customers/${testCustomerId}/conversation-items`).reply(400, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Test Event',
+      userId: testCustomerId,
+      properties: {
+        body: 'Test Body'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('conversationItem', {
+        event,
+        settings,
+        mapping: {
+          externalCustomerId: { '@path': '$.userId' },
+          title: { '@path': '$.event' },
+          body: { '@path': '$.properties.body' }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(HTTPError)
+  })
+  it('throws integration error when email, phone and external customer id is not included', async () => {
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Test Event',
+      properties: {
+        body: 'Test Body'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('conversationItem', {
+        event,
+        settings,
+        mapping: {
+          title: { '@path': '$.event' },
+          body: { '@path': '$.properties.body' }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(IntegrationError)
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/index.test.ts
@@ -39,6 +39,7 @@ describe('ConversationItem', () => {
 
     it('call find customer correctly', async () => {
       const response = await whenInvoked()
+
       expect(response[0].url).toMatchInlineSnapshot(
         `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?email=test%40example.com"`
       )
@@ -58,6 +59,7 @@ describe('ConversationItem', () => {
 
     it('calls create conversation correctly', async () => {
       const response = await whenInvoked()
+
       expect(response[1].url).toMatchInlineSnapshot(
         `"https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items"`
       )
@@ -86,6 +88,7 @@ describe('ConversationItem', () => {
 
     it('throws an integration error', async () => {
       const response = await whenInvoked()
+
       expect(response).toBeInstanceOf(IntegrationError)
     })
   })
@@ -97,7 +100,7 @@ describe('ConversationItem', () => {
 
     it('throws a http error', async () => {
       const response = await whenInvoked()
-      console.log(response)
+
       expect(response).toBeInstanceOf(HTTPError)
     })
   })
@@ -117,6 +120,7 @@ describe('ConversationItem', () => {
 
     it('throws a http error', async () => {
       const response = await whenInvoked()
+
       expect(response).toBeInstanceOf(HTTPError)
     })
   })

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/index.test.ts
@@ -13,145 +13,129 @@ const settings = {
 
 const baseUrl = `${settings.url}${API_VERSION}`
 
-describe('Gladly.conversationItem', () => {
-  const externalCustomerId = '123'
-
-  it('creates a conversation item', async () => {
-    nock(baseUrl)
-      .get(`/customer-profiles`)
-      .query({ externalCustomerId })
-      .reply(200, [
-        {
-          id: '123'
-        }
-      ])
-    nock(baseUrl).post(`/customers/123/conversation-items`).reply(200, {})
-
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      properties: {
-        body: 'Test Body'
-      }
-    })
-
-    const responses = await testDestination.testAction('conversationItem', {
-      event,
-      settings,
-      mapping: {
-        externalCustomerId: { '@path': '$.userId' },
-        title: { '@path': '$.event' },
-        body: { '@path': '$.properties.body' }
-      }
-    })
-
-    expect(responses.length).toBe(2)
-    expect(responses[0].status).toBe(200)
-    expect(responses[1].status).toBe(200)
-    expect(responses[1].options.body).toMatchInlineSnapshot(
-      `"{\\"customer\\":{},\\"content\\":{\\"type\\":\\"CUSTOMER_ACTIVITY\\",\\"title\\":\\"Test Event\\",\\"body\\":\\"Test Body\\",\\"activityType\\":\\"SMS\\",\\"sourceName\\":\\"Segment\\"}}"`
-    )
+describe('ConversationItem', () => {
+  const customerEmail = 'test@example.com'
+  const event = createTestEvent({
+    type: 'track',
+    event: 'Test Event',
+    properties: {
+      body: 'Test Body',
+      email: customerEmail
+    }
   })
 
-  it('throws integration error when customer does not exist', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId }).reply(200, [])
-
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      properties: {
-        body: 'Test Body'
-      }
+  describe('when a conversation item is successfully created', () => {
+    beforeEach(async () => {
+      nock(baseUrl)
+        .get(`/customer-profiles`)
+        .query({ email: customerEmail })
+        .reply(200, [
+          {
+            id: '123'
+          }
+        ])
+      nock(baseUrl).post(`/customers/123/conversation-items`).reply(200, {})
     })
 
-    let response, error
+    it('call find customer correctly', async () => {
+      const response = await whenInvoked()
+      expect(response[0].url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customer-profiles?email=test%40example.com"`
+      )
+      expect(response[0].options.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "authorization": Array [
+              "Basic ZXhhbXBsZUBnbGFkbHkuY29tOmdsYWRseQ==",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+    })
+
+    it('calls create conversation correctly', async () => {
+      const response = await whenInvoked()
+      expect(response[1].url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.com/api/v1/customers/123/conversation-items"`
+      )
+      expect(response[1].options.headers).toMatchInlineSnapshot(`
+      Headers {
+        Symbol(map): Object {
+          "authorization": Array [
+            "Basic ZXhhbXBsZUBnbGFkbHkuY29tOmdsYWRseQ==",
+          ],
+          "user-agent": Array [
+            "Segment (Actions)",
+          ],
+        },
+      }
+    `)
+      expect(response[1].options.body).toMatchInlineSnapshot(
+        `"{\\"customer\\":{\\"emailAddress\\":\\"test@example.com\\"},\\"content\\":{\\"type\\":\\"CUSTOMER_ACTIVITY\\",\\"title\\":\\"Test Event\\",\\"body\\":\\"Test Body\\",\\"activityType\\":\\"EMAIL\\",\\"sourceName\\":\\"Segment\\"}}"`
+      )
+    })
+  })
+
+  describe('when a customer does not exist', () => {
+    beforeEach(() => {
+      nock(baseUrl).get(`/customer-profiles`).query({ email: customerEmail }).reply(200, [])
+    })
+
+    it('throws an integration error', async () => {
+      const response = await whenInvoked()
+      expect(response).toBeInstanceOf(IntegrationError)
+    })
+  })
+
+  describe('when the find customer response is not 200', () => {
+    beforeEach(() => {
+      nock(baseUrl).get(`/customer-profiles`).query({ email: customerEmail }).reply(400, [])
+    })
+
+    it('throws a http error', async () => {
+      const response = await whenInvoked()
+      console.log(response)
+      expect(response).toBeInstanceOf(HTTPError)
+    })
+  })
+
+  describe('when create conversation is unsuccessful', () => {
+    beforeEach(() => {
+      nock(baseUrl)
+        .get(`/customer-profiles`)
+        .query({ email: customerEmail })
+        .reply(200, [
+          {
+            id: '123'
+          }
+        ])
+      nock(baseUrl).post(`/customers/123/conversation-items`).reply(400, {})
+    })
+
+    it('throws a http error', async () => {
+      const response = await whenInvoked()
+      expect(response).toBeInstanceOf(HTTPError)
+    })
+  })
+
+  async function whenInvoked() {
     try {
-      response = await testDestination.testAction('conversationItem', {
+      return await testDestination.testAction('conversationItem', {
         event,
         settings,
         mapping: {
-          externalCustomerId: { '@path': '$.userId' },
+          email: { '@path': '$.properties.email' },
           title: { '@path': '$.event' },
-          body: { '@path': '$.properties.body' }
+          body: { '@path': '$.properties.body' },
+          activityType: 'EMAIL',
+          sourceName: 'Segment'
         }
       })
     } catch (e) {
-      error = e
+      return e
     }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(IntegrationError)
-  })
-
-  it('throws http error when find customer response is not 200', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId }).reply(400, [])
-
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      properties: {
-        body: 'Test Body'
-      }
-    })
-
-    let response, error
-    try {
-      response = await testDestination.testAction('conversationItem', {
-        event,
-        settings,
-        mapping: {
-          externalCustomerId: { '@path': '$.userId' },
-          title: { '@path': '$.event' },
-          body: { '@path': '$.properties.body' }
-        }
-      })
-    } catch (e) {
-      error = e
-    }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(HTTPError)
-  })
-
-  it('throws http error when create conversation item is not 200', async () => {
-    nock(baseUrl)
-      .get(`/customer-profiles`)
-      .query({ externalCustomerId })
-      .reply(200, [
-        {
-          id: '123'
-        }
-      ])
-    nock(baseUrl).post(`/customers/123/conversation-items`).reply(400, {})
-
-    const event = createTestEvent({
-      type: 'track',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      properties: {
-        body: 'Test Body'
-      }
-    })
-
-    let response, error
-    try {
-      response = await testDestination.testAction('conversationItem', {
-        event,
-        settings,
-        mapping: {
-          externalCustomerId: { '@path': '$.userId' },
-          title: { '@path': '$.event' },
-          body: { '@path': '$.properties.body' }
-        }
-      })
-    } catch (e) {
-      error = e
-    }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(HTTPError)
-  })
+  }
 })

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/snapshot.test.ts
@@ -8,6 +8,7 @@ const actionSlug = 'conversationItem'
 const destinationSlug = 'Gladly'
 const seedName = `${destinationSlug}#${actionSlug}`
 const url = 'https://test-org.us-1.gladly.com'
+const email = 'test@gladly.com'
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
@@ -21,11 +22,12 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
 
+    eventData.email = email
+    settingsData.url = url
+
     const event = createTestEvent({
       properties: eventData
     })
-
-    settingsData.url = url
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/snapshot.test.ts
@@ -7,19 +7,25 @@ const testDestination = createTestIntegration(destination)
 const actionSlug = 'conversationItem'
 const destinationSlug = 'Gladly'
 const seedName = `${destinationSlug}#${actionSlug}`
+const url = 'https://test-org.us-1.gladly.com'
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/)
+      .persist()
+      .get(/.*/)
+      .reply(200, [{ id: '123' }])
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData
     })
+
+    settingsData.url = url
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
@@ -46,13 +52,18 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
-    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/)
+      .persist()
+      .get(/.*/)
+      .reply(200, [{ id: '123' }])
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData
     })
+
+    settingsData.url = url
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/__tests__/snapshot.test.ts
@@ -1,0 +1,76 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'conversationItem'
+const destinationSlug = 'Gladly'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      console.log(json)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
@@ -12,7 +12,7 @@ export interface Payload {
   /**
    * Customer ID in your system of record.
    */
-  externalCustomerId?: string
+  externalCustomerId: string
   /**
    * First line of highlighted text for the item in the customer timeline,
    */

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
@@ -6,7 +6,7 @@ export interface Payload {
    */
   email?: string
   /**
-   * Mobile phone number for the customer
+   * Mobile phone number for the customer. Please ensure the number is either entered as is or following the E.164 format
    */
   phone?: string
   /**

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
@@ -10,10 +10,6 @@ export interface Payload {
    */
   phone?: string
   /**
-   * Customer ID in your system of record.
-   */
-  externalCustomerId: string
-  /**
    * First line of highlighted text for the item in the customer timeline,
    */
   title: string
@@ -21,4 +17,12 @@ export interface Payload {
    * Plain text or rich content of the activity that will appear as the main content.
    */
   body: string
+  /**
+   * Type of this activity. This will determine the icon displayed in the customer timeline.
+   */
+  activityType: string
+  /**
+   * Name of the source system generating this activity
+   */
+  sourceName: string
 }

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/generated-types.ts
@@ -1,0 +1,24 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Email address for the customer
+   */
+  email?: string
+  /**
+   * Mobile phone number for the customer
+   */
+  phone?: string
+  /**
+   * Customer ID in your system of record.
+   */
+  externalCustomerId?: string
+  /**
+   * First line of highlighted text for the item in the customer timeline,
+   */
+  title: string
+  /**
+   * Plain text or rich content of the activity that will appear as the main content.
+   */
+  body: string
+}

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Gladly } from '../gladly-operations'
-import { email, phone, externalCustomerId } from '../gladly-properties'
+import { email, phone, externalCustomerId } from '../gladly-shared-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Conversation Item',

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { Gladly } from '../gladly-operations'
-import { email, phone, externalCustomerId } from '../gladly-shared-properties'
+import { email, phone } from '../gladly-shared-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Conversation Item',
@@ -10,7 +10,6 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     email,
     phone,
-    externalCustomerId,
     title: {
       label: 'Title',
       description: 'First line of highlighted text for the item in the customer timeline,',
@@ -25,14 +24,41 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Plain text or rich content of the activity that will appear as the main content.',
       type: 'string',
       required: true
+    },
+    activityType: {
+      label: 'Activity Type',
+      description: 'Type of this activity. This will determine the icon displayed in the customer timeline.',
+      type: 'string',
+      choices: [
+        { label: 'Email', value: 'EMAIL' },
+        { label: 'SMS', value: 'SMS' },
+        { label: 'Issue', value: 'ISSUE' },
+        { label: 'Survey', value: 'SURVEY' }
+      ],
+      required: true
+    },
+    sourceName: {
+      label: 'Source Name',
+      description: 'Name of the source system generating this activity',
+      type: 'string',
+      required: true
     }
   },
   perform: async (request, { settings, payload }) => {
     const gladly = new Gladly(settings, request)
 
-    const response = await gladly.findCustomer(payload)
-    if (response) {
-      const customerId = response.data[0].id
+    let customer
+
+    if (payload.email) {
+      customer = await gladly.findCustomerByEmail(payload.email)
+    } else if (payload.phone) {
+      customer = await gladly.findCustomerByPhone(payload.phone)
+    } else {
+      throw new IntegrationError('Unable to ')
+    }
+
+    if (customer.data.length) {
+      const customerId = customer.data[0].id
       return await gladly.createConversationItem(customerId, payload)
     } else {
       throw new IntegrationError('Unable to find customer')

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
@@ -1,0 +1,43 @@
+import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Gladly } from '../gladly-operations'
+import { email, phone, externalCustomerId } from '../gladly-properties'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Conversation Item',
+  description: '',
+  fields: {
+    email,
+    phone,
+    externalCustomerId,
+    title: {
+      label: 'Title',
+      description: 'First line of highlighted text for the item in the customer timeline,',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.event'
+      }
+    },
+    body: {
+      label: 'Body',
+      description: 'Plain text or rich content of the activity that will appear as the main content.',
+      type: 'string',
+      required: true
+    }
+  },
+  perform: async (request, { settings, payload }) => {
+    const gladly = new Gladly(settings, request)
+
+    const response = await gladly.findCustomer(payload)
+    if (response) {
+      const customerId = response.data[0].id
+      return await gladly.createConversationItem(customerId, payload)
+    } else {
+      throw new IntegrationError('Unable to find customer')
+    }
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/conversationItem/index.ts
@@ -54,14 +54,14 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (payload.phone) {
       customer = await gladly.findCustomerByPhone(payload.phone)
     } else {
-      throw new IntegrationError('Unable to ')
+      throw new IntegrationError('Please pass either an email or phone number as part of the request', '400', 400)
     }
 
     if (customer.data.length) {
       const customerId = customer.data[0].id
       return await gladly.createConversationItem(customerId, payload)
     } else {
-      throw new IntegrationError('Unable to find customer')
+      throw new IntegrationError('Unable to find customer with the email or phone number provided', '400', 400)
     }
   }
 }

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Gladly's customer destination action: all fields 1`] = `""`;
+
+exports[`Testing snapshot for Gladly's customer destination action: required fields 1`] = `""`;
+
+exports[`Testing snapshot for Gladly's customer destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Basic NSE4QW9sZXV5OVgkSjo1IThBb2xldXk5WCRK",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration, HTTPError, IntegrationError } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, HTTPError } from '@segment/actions-core'
 import Destination from '../../index'
 import { API_VERSION } from '../../gladly-operations'
 
@@ -8,28 +8,31 @@ const testDestination = createTestIntegration(Destination)
 const settings = {
   username: 'example@gladly.com',
   password: 'gladly',
-  orgName: 'test-org',
-  isSandbox: false
+  url: 'https://test-org.us-1.gladly.qa'
 }
 
-const baseUrl = `https://${settings.orgName}.us-1.gladly.com${API_VERSION}`
+const baseUrl = `${settings.url}${API_VERSION}`
 
 describe('Gladly.customer', () => {
-  const testCustomerEmail = 'joe.bob@gladly.com'
-  const customerId = '123'
+  const email = 'joe.bob@gladly.com'
+  const phone = '2345678901'
+  const externalCustomerId = '123'
 
   it('does not find a customer and creates a customer profile', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ email: testCustomerEmail }).reply(200, [])
-    nock(baseUrl).post(`/customer-profiles`).reply(201, {})
+    nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(200, [])
+    nock(baseUrl).get(`/customer-profiles`).query({ phoneNumber: phone }).reply(200, [])
+    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId }).reply(200, [])
+
+    nock(baseUrl).post(`/customer-profiles`).reply(201, { id: '123' })
 
     const event = createTestEvent({
       type: 'identify',
       event: 'Test Event',
-      userId: '123',
+      userId: externalCustomerId,
       traits: {
         name: 'Joe Bob',
-        email: testCustomerEmail,
-        phone: '2345678901',
+        email,
+        phone,
         address: '123 Test St. New York City NY US 10001',
         tier: 'vip'
       }
@@ -44,30 +47,35 @@ describe('Gladly.customer', () => {
         phone: { '@path': '$.traits.phone' },
         externalCustomerId: { '@path': '$.userId' },
         address: { '@path': '$.traits.address' },
-        customAttributes: { tier: { '@path': '$.traits.address.country' } }
+        customAttributes: { tier: { '@path': '$.traits.tier' } }
       }
     })
 
-    expect(responses.length).toBe(2)
+    expect(responses.length).toBe(4)
     expect(responses[0].status).toBe(200)
-    expect(responses[1].status).toBe(201)
+    expect(responses[1].status).toBe(200)
+    expect(responses[2].status).toBe(200)
+    expect(responses[3].status).toBe(201)
+    expect(responses[3].options.body).toMatchInlineSnapshot(
+      `"{\\"name\\":\\"Joe Bob\\",\\"address\\":\\"123 Test St. New York City NY US 10001\\",\\"emails\\":[{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":true}],\\"phones\\":[{\\"original\\":\\"2345678901\\",\\"primary\\":true}],\\"externalCustomerId\\":\\"123\\",\\"customAttributes\\":{\\"tier\\":\\"vip\\"}}"`
+    )
   })
 
   it('finds a customer and updates a customer profile', async () => {
     nock(baseUrl)
       .get(`/customer-profiles`)
-      .query({ email: testCustomerEmail })
-      .reply(200, [{ id: customerId }])
-    nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(204, {})
+      .query({ email: email })
+      .reply(200, [{ id: '123' }])
+    nock(baseUrl).patch(`/customer-profiles/123`).reply(204, {})
 
     const event = createTestEvent({
       type: 'identify',
       event: 'Test Event',
-      userId: '123',
+      userId: externalCustomerId,
       traits: {
         name: 'Joe Bob',
-        email: testCustomerEmail,
-        phone: '2345678901',
+        email,
+        phone,
         address: '123 Test St. New York City NY US 10001',
         tier: 'vip'
       }
@@ -82,25 +90,29 @@ describe('Gladly.customer', () => {
         phone: { '@path': '$.traits.phone' },
         externalCustomerId: { '@path': '$.userId' },
         address: { '@path': '$.traits.address' },
-        customAttributes: { tier: { '@path': '$.traits.address.country' } }
+        customAttributes: { tier: { '@path': '$.traits.tier' } }
       }
     })
 
     expect(responses.length).toBe(2)
     expect(responses[0].status).toBe(200)
     expect(responses[1].status).toBe(204)
+    expect(responses[1].options.body).toMatchInlineSnapshot(
+      `"{\\"name\\":\\"Joe Bob\\",\\"address\\":\\"123 Test St. New York City NY US 10001\\",\\"emails\\":[{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":true}],\\"phones\\":[{\\"original\\":\\"2345678901\\",\\"primary\\":true}],\\"externalCustomerId\\":\\"123\\",\\"customAttributes\\":{\\"tier\\":\\"vip\\"}}"`
+    )
   })
+
   it('throws http error when find customer fails', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ email: testCustomerEmail }).reply(400)
+    nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400)
 
     const event = createTestEvent({
       type: 'identify',
       event: 'Test Event',
-      userId: '123',
+      userId: externalCustomerId,
       traits: {
         name: 'Joe Bob',
-        email: testCustomerEmail,
-        phone: '2345678901',
+        email,
+        phone,
         address: '123 Test St. New York City NY US 10001',
         tier: 'vip'
       }
@@ -117,7 +129,7 @@ describe('Gladly.customer', () => {
           phone: { '@path': '$.traits.phone' },
           externalCustomerId: { '@path': '$.userId' },
           address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+          customAttributes: { tier: { '@path': '$.traits.tier' } }
         }
       })
     } catch (e) {
@@ -127,18 +139,22 @@ describe('Gladly.customer', () => {
     expect(response).toBeUndefined()
     expect(error).toBeInstanceOf(HTTPError)
   })
+
   it('throws http error when create customer fails', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ email: testCustomerEmail }).reply(200, [])
+    nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(200, [])
+    nock(baseUrl).get(`/customer-profiles`).query({ phoneNumber: phone }).reply(200, [])
+    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId }).reply(200, [])
+
     nock(baseUrl).post(`/customer-profiles`).reply(400)
 
     const event = createTestEvent({
       type: 'identify',
       event: 'Test Event',
-      userId: '123',
+      userId: externalCustomerId,
       traits: {
         name: 'Joe Bob',
-        email: testCustomerEmail,
-        phone: '2345678901',
+        email,
+        phone,
         address: '123 Test St. New York City NY US 10001',
         tier: 'vip'
       }
@@ -155,7 +171,7 @@ describe('Gladly.customer', () => {
           phone: { '@path': '$.traits.phone' },
           externalCustomerId: { '@path': '$.userId' },
           address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+          customAttributes: { tier: { '@path': '$.traits.tier' } }
         }
       })
     } catch (e) {
@@ -165,25 +181,26 @@ describe('Gladly.customer', () => {
     expect(response).toBeUndefined()
     expect(error).toBeInstanceOf(HTTPError)
   })
+
   it('throws http error when update customer fails', async () => {
     nock(baseUrl)
       .get(`/customer-profiles`)
-      .query({ email: testCustomerEmail })
+      .query({ email })
       .reply(200, [
         {
           id: '123'
         }
       ])
-    nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(400)
+    nock(baseUrl).patch(`/customer-profiles/123`).reply(400)
 
     const event = createTestEvent({
       type: 'identify',
       event: 'Test Event',
-      userId: '123',
+      userId: externalCustomerId,
       traits: {
         name: 'Joe Bob',
-        email: testCustomerEmail,
-        phone: '2345678901',
+        email,
+        phone,
         address: '123 Test St. New York City NY US 10001',
         tier: 'vip'
       }
@@ -200,7 +217,7 @@ describe('Gladly.customer', () => {
           phone: { '@path': '$.traits.phone' },
           externalCustomerId: { '@path': '$.userId' },
           address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+          customAttributes: { tier: { '@path': '$.traits.tier' } }
         }
       })
     } catch (e) {
@@ -209,34 +226,5 @@ describe('Gladly.customer', () => {
 
     expect(response).toBeUndefined()
     expect(error).toBeInstanceOf(HTTPError)
-  })
-  it('throws integration error when email, phone and external customer id is not included', async () => {
-    const event = createTestEvent({
-      type: 'identify',
-      event: 'Test Event',
-      traits: {
-        name: 'Joe Bob',
-        address: '123 Test St. New York City NY US 10001',
-        tier: 'vip'
-      }
-    })
-
-    let response, error
-    try {
-      response = await testDestination.testAction('customer', {
-        event,
-        settings,
-        mapping: {
-          name: { '@path': '$.traits.name' },
-          address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.address.country' } }
-        }
-      })
-    } catch (e) {
-      error = e
-    }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(IntegrationError)
   })
 })

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
@@ -1,0 +1,242 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, HTTPError, IntegrationError } from '@segment/actions-core'
+import Destination from '../../index'
+import { API_VERSION } from '../../gladly-operations'
+
+const testDestination = createTestIntegration(Destination)
+
+const settings = {
+  username: 'example@gladly.com',
+  password: 'gladly',
+  orgName: 'test-org',
+  isSandbox: false
+}
+
+const baseUrl = `https://${settings.orgName}.us-1.gladly.com${API_VERSION}`
+
+describe('Gladly.customer', () => {
+  const testCustomerEmail = 'joe.bob@gladly.com'
+  const customerId = '123'
+
+  it('does not find a customer and creates a customer profile', async () => {
+    nock(baseUrl).get(`/customer-profiles`).query({ email: testCustomerEmail }).reply(200, [])
+    nock(baseUrl).post(`/customer-profiles`).reply(201, {})
+
+    const event = createTestEvent({
+      type: 'identify',
+      event: 'Test Event',
+      userId: '123',
+      traits: {
+        name: 'Joe Bob',
+        email: testCustomerEmail,
+        phone: '2345678901',
+        address: '123 Test St. New York City NY US 10001',
+        tier: 'vip'
+      }
+    })
+
+    const responses = await testDestination.testAction('customer', {
+      event,
+      settings,
+      mapping: {
+        name: { '@path': '$.traits.name' },
+        email: { '@path': '$.traits.email' },
+        phone: { '@path': '$.traits.phone' },
+        externalCustomerId: { '@path': '$.userId' },
+        address: { '@path': '$.traits.address' },
+        customAttributes: { tier: { '@path': '$.traits.address.country' } }
+      }
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[1].status).toBe(201)
+  })
+
+  it('finds a customer and updates a customer profile', async () => {
+    nock(baseUrl)
+      .get(`/customer-profiles`)
+      .query({ email: testCustomerEmail })
+      .reply(200, [{ id: customerId }])
+    nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(204, {})
+
+    const event = createTestEvent({
+      type: 'identify',
+      event: 'Test Event',
+      userId: '123',
+      traits: {
+        name: 'Joe Bob',
+        email: testCustomerEmail,
+        phone: '2345678901',
+        address: '123 Test St. New York City NY US 10001',
+        tier: 'vip'
+      }
+    })
+
+    const responses = await testDestination.testAction('customer', {
+      event,
+      settings,
+      mapping: {
+        name: { '@path': '$.traits.name' },
+        email: { '@path': '$.traits.email' },
+        phone: { '@path': '$.traits.phone' },
+        externalCustomerId: { '@path': '$.userId' },
+        address: { '@path': '$.traits.address' },
+        customAttributes: { tier: { '@path': '$.traits.address.country' } }
+      }
+    })
+
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(200)
+    expect(responses[1].status).toBe(204)
+  })
+  it('throws http error when find customer fails', async () => {
+    nock(baseUrl).get(`/customer-profiles`).query({ email: testCustomerEmail }).reply(400)
+
+    const event = createTestEvent({
+      type: 'identify',
+      event: 'Test Event',
+      userId: '123',
+      traits: {
+        name: 'Joe Bob',
+        email: testCustomerEmail,
+        phone: '2345678901',
+        address: '123 Test St. New York City NY US 10001',
+        tier: 'vip'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('customer', {
+        event,
+        settings,
+        mapping: {
+          name: { '@path': '$.traits.name' },
+          email: { '@path': '$.traits.email' },
+          phone: { '@path': '$.traits.phone' },
+          externalCustomerId: { '@path': '$.userId' },
+          address: { '@path': '$.traits.address' },
+          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(HTTPError)
+  })
+  it('throws http error when create customer fails', async () => {
+    nock(baseUrl).get(`/customer-profiles`).query({ email: testCustomerEmail }).reply(200, [])
+    nock(baseUrl).post(`/customer-profiles`).reply(400)
+
+    const event = createTestEvent({
+      type: 'identify',
+      event: 'Test Event',
+      userId: '123',
+      traits: {
+        name: 'Joe Bob',
+        email: testCustomerEmail,
+        phone: '2345678901',
+        address: '123 Test St. New York City NY US 10001',
+        tier: 'vip'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('customer', {
+        event,
+        settings,
+        mapping: {
+          name: { '@path': '$.traits.name' },
+          email: { '@path': '$.traits.email' },
+          phone: { '@path': '$.traits.phone' },
+          externalCustomerId: { '@path': '$.userId' },
+          address: { '@path': '$.traits.address' },
+          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(HTTPError)
+  })
+  it('throws http error when update customer fails', async () => {
+    nock(baseUrl)
+      .get(`/customer-profiles`)
+      .query({ email: testCustomerEmail })
+      .reply(200, [
+        {
+          id: '123'
+        }
+      ])
+    nock(baseUrl).patch(`/customer-profiles/${customerId}`).reply(400)
+
+    const event = createTestEvent({
+      type: 'identify',
+      event: 'Test Event',
+      userId: '123',
+      traits: {
+        name: 'Joe Bob',
+        email: testCustomerEmail,
+        phone: '2345678901',
+        address: '123 Test St. New York City NY US 10001',
+        tier: 'vip'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('customer', {
+        event,
+        settings,
+        mapping: {
+          name: { '@path': '$.traits.name' },
+          email: { '@path': '$.traits.email' },
+          phone: { '@path': '$.traits.phone' },
+          externalCustomerId: { '@path': '$.userId' },
+          address: { '@path': '$.traits.address' },
+          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(HTTPError)
+  })
+  it('throws integration error when email, phone and external customer id is not included', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      event: 'Test Event',
+      traits: {
+        name: 'Joe Bob',
+        address: '123 Test St. New York City NY US 10001',
+        tier: 'vip'
+      }
+    })
+
+    let response, error
+    try {
+      response = await testDestination.testAction('customer', {
+        event,
+        settings,
+        mapping: {
+          name: { '@path': '$.traits.name' },
+          address: { '@path': '$.traits.address' },
+          customAttributes: { tier: { '@path': '$.traits.address.country' } }
+        }
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(response).toBeUndefined()
+    expect(error).toBeInstanceOf(IntegrationError)
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
@@ -98,6 +98,7 @@ describe('Gladly.customer', () => {
 
       it('calls update customer correctly', async () => {
         const response = await whenInvoked(override)
+
         expect(response[1].url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.qa/api/v1/customer-profiles/123"`)
         expect(response[1].options.headers).toMatchInlineSnapshot(`
                   Headers {
@@ -129,6 +130,7 @@ describe('Gladly.customer', () => {
 
       it('calls update customer correctly', async () => {
         const response = await whenInvoked(override)
+
         expect(response[1].url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.qa/api/v1/customer-profiles/123"`)
         expect(response[1].options.headers).toMatchInlineSnapshot(`
                   Headers {
@@ -142,15 +144,14 @@ describe('Gladly.customer', () => {
                     },
                   }
               `)
-        expect(response[1].options.body).toMatchInlineSnapshot(
-          `"{\\"name\\":\\"Jane Doe\\",\\"address\\":\\"34 Gladly St. Houston TX 77002\\",\\"emails\\":[{\\"original\\":\\"joedoe@gladly.com\\",\\"primary\\":true},{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":false}],\\"phones\\":[{\\"original\\":\\"5678901234\\",\\"primary\\":true},{\\"original\\":\\"2345678901\\",\\"primary\\":false}],\\"customAttributes\\":{\\"tier\\":\\"regular\\"}}"`
-        )
+        expect(response[1].options.body).toMatchInlineSnapshot(`"{}"`)
       })
     })
   })
 
   describe('when find customer fails', () => {
     const override = false
+
     beforeEach(() => {
       nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400)
     })
@@ -184,6 +185,7 @@ describe('Gladly.customer', () => {
   function itCallsFindCustomerCorrectly(override: boolean) {
     it('calls find customer with the correct url', async () => {
       const response = await whenInvoked(override)
+
       expect(response[0].url).toMatchInlineSnapshot(
         `"https://test-org.us-1.gladly.qa/api/v1/customer-profiles?email=joe.bob%40gladly.com"`
       )

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration, HTTPError } from '@segment/actions-core'
 import Destination from '../../index'
 import { API_VERSION } from '../../gladly-operations'
+import { Customer } from '../../gladly-shared-types'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -16,215 +17,207 @@ const baseUrl = `${settings.url}${API_VERSION}`
 describe('Gladly.customer', () => {
   const email = 'joe.bob@gladly.com'
   const phone = '2345678901'
-  const externalCustomerId = '123'
 
-  it('does not find a customer and creates a customer profile', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(200, [])
-    nock(baseUrl).get(`/customer-profiles`).query({ phoneNumber: phone }).reply(200, [])
-    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId }).reply(200, [])
-
-    nock(baseUrl).post(`/customer-profiles`).reply(201, { id: '123' })
-
-    const event = createTestEvent({
-      type: 'identify',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      traits: {
-        name: 'Joe Bob',
-        email,
-        phone,
-        address: '123 Test St. New York City NY US 10001',
-        tier: 'vip'
-      }
-    })
-
-    const responses = await testDestination.testAction('customer', {
-      event,
-      settings,
-      mapping: {
-        name: { '@path': '$.traits.name' },
-        email: { '@path': '$.traits.email' },
-        phone: { '@path': '$.traits.phone' },
-        externalCustomerId: { '@path': '$.userId' },
-        address: { '@path': '$.traits.address' },
-        customAttributes: { tier: { '@path': '$.traits.tier' } }
-      }
-    })
-
-    expect(responses.length).toBe(4)
-    expect(responses[0].status).toBe(200)
-    expect(responses[1].status).toBe(200)
-    expect(responses[2].status).toBe(200)
-    expect(responses[3].status).toBe(201)
-    expect(responses[3].options.body).toMatchInlineSnapshot(
-      `"{\\"name\\":\\"Joe Bob\\",\\"address\\":\\"123 Test St. New York City NY US 10001\\",\\"emails\\":[{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":true}],\\"phones\\":[{\\"original\\":\\"2345678901\\",\\"primary\\":true}],\\"externalCustomerId\\":\\"123\\",\\"customAttributes\\":{\\"tier\\":\\"vip\\"}}"`
-    )
+  const event = createTestEvent({
+    type: 'identify',
+    event: 'Test Event',
+    traits: {
+      name: 'Joe Bob',
+      email,
+      phone,
+      address: '123 Test St. New York City NY US 10001',
+      tier: 'vip'
+    }
   })
 
-  it('finds a customer and updates a customer profile', async () => {
-    nock(baseUrl)
-      .get(`/customer-profiles`)
-      .query({ email: email })
-      .reply(200, [{ id: '123' }])
-    nock(baseUrl).patch(`/customer-profiles/123`).reply(204, {})
+  describe('create customer', () => {
+    describe('when the request is successful', () => {
+      const override = false
 
-    const event = createTestEvent({
-      type: 'identify',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      traits: {
-        name: 'Joe Bob',
-        email,
-        phone,
-        address: '123 Test St. New York City NY US 10001',
-        tier: 'vip'
-      }
+      beforeEach(() => {
+        nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(200, [])
+        nock(baseUrl).post(`/customer-profiles`).reply(201, { id: '123' })
+      })
+
+      itCallsFindCustomerCorrectly(override)
+
+      it('calls create customer correctly', async () => {
+        const response = await whenInvoked(override)
+        expect(response[1].url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.qa/api/v1/customer-profiles"`)
+        expect(response[1].options.headers).toMatchInlineSnapshot(`
+                  Headers {
+                    Symbol(map): Object {
+                      "authorization": Array [
+                        "Basic ZXhhbXBsZUBnbGFkbHkuY29tOmdsYWRseQ==",
+                      ],
+                      "user-agent": Array [
+                        "Segment (Actions)",
+                      ],
+                    },
+                  }
+              `)
+        expect(response[1].options.body).toMatchInlineSnapshot(
+          `"{\\"name\\":\\"Joe Bob\\",\\"address\\":\\"123 Test St. New York City NY US 10001\\",\\"emails\\":[{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":false}],\\"phones\\":[{\\"original\\":\\"2345678901\\",\\"primary\\":false}],\\"customAttributes\\":{\\"tier\\":\\"vip\\"}}"`
+        )
+      })
     })
 
-    const responses = await testDestination.testAction('customer', {
-      event,
-      settings,
-      mapping: {
-        name: { '@path': '$.traits.name' },
-        email: { '@path': '$.traits.email' },
-        phone: { '@path': '$.traits.phone' },
-        externalCustomerId: { '@path': '$.userId' },
-        address: { '@path': '$.traits.address' },
-        customAttributes: { tier: { '@path': '$.traits.tier' } }
-      }
-    })
+    describe('when the request fails', () => {
+      const override = false
+      beforeEach(() => {
+        nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400)
+      })
 
-    expect(responses.length).toBe(2)
-    expect(responses[0].status).toBe(200)
-    expect(responses[1].status).toBe(204)
-    expect(responses[1].options.body).toMatchInlineSnapshot(
-      `"{\\"name\\":\\"Joe Bob\\",\\"address\\":\\"123 Test St. New York City NY US 10001\\",\\"emails\\":[{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":true}],\\"phones\\":[{\\"original\\":\\"2345678901\\",\\"primary\\":true}],\\"externalCustomerId\\":\\"123\\",\\"customAttributes\\":{\\"tier\\":\\"vip\\"}}"`
-    )
+      it('throws an http error', async () => {
+        const response = await whenInvoked(override)
+        expect(response).toBeInstanceOf(HTTPError)
+      })
+    })
   })
 
-  it('throws http error when find customer fails', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400)
+  describe('when update customer is successful', () => {
+    const existingCustomer: Customer = {
+      id: '123',
+      name: 'Jane Doe',
+      emails: [{ original: 'joedoe@gladly.com', primary: true }],
+      phones: [{ original: '5678901234', primary: true }],
+      address: '34 Gladly St. Houston TX 77002',
+      customAttributes: { tier: 'regular' },
+      createdAt: '2022-08-04'
+    }
 
-    const event = createTestEvent({
-      type: 'identify',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      traits: {
-        name: 'Joe Bob',
-        email,
-        phone,
-        address: '123 Test St. New York City NY US 10001',
-        tier: 'vip'
-      }
+    describe('when override is true', () => {
+      const override = true
+
+      beforeEach(() => {
+        nock(baseUrl).get(`/customer-profiles`).query({ email: email }).reply(200, [existingCustomer])
+        nock(baseUrl).patch(`/customer-profiles/123`).reply(204, {})
+      })
+
+      itCallsFindCustomerCorrectly(override)
+
+      it('calls update customer correctly', async () => {
+        const response = await whenInvoked(override)
+        expect(response[1].url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.qa/api/v1/customer-profiles/123"`)
+        expect(response[1].options.headers).toMatchInlineSnapshot(`
+                  Headers {
+                    Symbol(map): Object {
+                      "authorization": Array [
+                        "Basic ZXhhbXBsZUBnbGFkbHkuY29tOmdsYWRseQ==",
+                      ],
+                      "user-agent": Array [
+                        "Segment (Actions)",
+                      ],
+                    },
+                  }
+              `)
+        expect(response[1].options.body).toMatchInlineSnapshot(
+          `"{\\"name\\":\\"Joe Bob\\",\\"address\\":\\"123 Test St. New York City NY US 10001\\",\\"emails\\":[{\\"original\\":\\"joedoe@gladly.com\\",\\"primary\\":true},{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":false}],\\"phones\\":[{\\"original\\":\\"5678901234\\",\\"primary\\":true},{\\"original\\":\\"2345678901\\",\\"primary\\":false}],\\"customAttributes\\":{\\"tier\\":\\"vip\\"}}"`
+        )
+      })
     })
 
-    let response, error
+    describe('when override is false', () => {
+      const override = false
+
+      beforeEach(() => {
+        nock(baseUrl).get(`/customer-profiles`).query({ email: email }).reply(200, [existingCustomer])
+        nock(baseUrl).patch(`/customer-profiles/123`).reply(204, {})
+      })
+
+      itCallsFindCustomerCorrectly(override)
+
+      it('calls update customer correctly', async () => {
+        const response = await whenInvoked(override)
+        expect(response[1].url).toMatchInlineSnapshot(`"https://test-org.us-1.gladly.qa/api/v1/customer-profiles/123"`)
+        expect(response[1].options.headers).toMatchInlineSnapshot(`
+                  Headers {
+                    Symbol(map): Object {
+                      "authorization": Array [
+                        "Basic ZXhhbXBsZUBnbGFkbHkuY29tOmdsYWRseQ==",
+                      ],
+                      "user-agent": Array [
+                        "Segment (Actions)",
+                      ],
+                    },
+                  }
+              `)
+        expect(response[1].options.body).toMatchInlineSnapshot(
+          `"{\\"name\\":\\"Jane Doe\\",\\"address\\":\\"34 Gladly St. Houston TX 77002\\",\\"emails\\":[{\\"original\\":\\"joedoe@gladly.com\\",\\"primary\\":true},{\\"original\\":\\"joe.bob@gladly.com\\",\\"primary\\":false}],\\"phones\\":[{\\"original\\":\\"5678901234\\",\\"primary\\":true},{\\"original\\":\\"2345678901\\",\\"primary\\":false}],\\"customAttributes\\":{\\"tier\\":\\"regular\\"}}"`
+        )
+      })
+    })
+  })
+
+  describe('when find customer fails', () => {
+    const override = false
+    beforeEach(() => {
+      nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(400)
+    })
+
+    it('throws an http error', async () => {
+      const response = await whenInvoked(override)
+      expect(response).toBeInstanceOf(HTTPError)
+    })
+  })
+
+  describe('when update customer fails', () => {
+    const override = false
+    beforeEach(() => {
+      nock(baseUrl)
+        .get(`/customer-profiles`)
+        .query({ email })
+        .reply(200, [
+          {
+            id: '123'
+          }
+        ])
+      nock(baseUrl).patch(`/customer-profiles/123`).reply(400)
+    })
+
+    it('throws an http error', async () => {
+      const response = await whenInvoked(override)
+      expect(response).toBeInstanceOf(HTTPError)
+    })
+  })
+
+  function itCallsFindCustomerCorrectly(override: boolean) {
+    it('calls find customer with the correct url', async () => {
+      const response = await whenInvoked(override)
+      expect(response[0].url).toMatchInlineSnapshot(
+        `"https://test-org.us-1.gladly.qa/api/v1/customer-profiles?email=joe.bob%40gladly.com"`
+      )
+      expect(response[0].options.headers).toMatchInlineSnapshot(`
+              Headers {
+                Symbol(map): Object {
+                  "authorization": Array [
+                    "Basic ZXhhbXBsZUBnbGFkbHkuY29tOmdsYWRseQ==",
+                  ],
+                  "user-agent": Array [
+                    "Segment (Actions)",
+                  ],
+                },
+              }
+          `)
+    })
+  }
+
+  async function whenInvoked(override: boolean) {
     try {
-      response = await testDestination.testAction('customer', {
+      return await testDestination.testAction('customer', {
         event,
         settings,
         mapping: {
           name: { '@path': '$.traits.name' },
           email: { '@path': '$.traits.email' },
           phone: { '@path': '$.traits.phone' },
-          externalCustomerId: { '@path': '$.userId' },
           address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.tier' } }
+          customAttributes: { tier: { '@path': '$.traits.tier' } },
+          override
         }
       })
     } catch (e) {
-      error = e
+      return e
     }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(HTTPError)
-  })
-
-  it('throws http error when create customer fails', async () => {
-    nock(baseUrl).get(`/customer-profiles`).query({ email }).reply(200, [])
-    nock(baseUrl).get(`/customer-profiles`).query({ phoneNumber: phone }).reply(200, [])
-    nock(baseUrl).get(`/customer-profiles`).query({ externalCustomerId }).reply(200, [])
-
-    nock(baseUrl).post(`/customer-profiles`).reply(400)
-
-    const event = createTestEvent({
-      type: 'identify',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      traits: {
-        name: 'Joe Bob',
-        email,
-        phone,
-        address: '123 Test St. New York City NY US 10001',
-        tier: 'vip'
-      }
-    })
-
-    let response, error
-    try {
-      response = await testDestination.testAction('customer', {
-        event,
-        settings,
-        mapping: {
-          name: { '@path': '$.traits.name' },
-          email: { '@path': '$.traits.email' },
-          phone: { '@path': '$.traits.phone' },
-          externalCustomerId: { '@path': '$.userId' },
-          address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.tier' } }
-        }
-      })
-    } catch (e) {
-      error = e
-    }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(HTTPError)
-  })
-
-  it('throws http error when update customer fails', async () => {
-    nock(baseUrl)
-      .get(`/customer-profiles`)
-      .query({ email })
-      .reply(200, [
-        {
-          id: '123'
-        }
-      ])
-    nock(baseUrl).patch(`/customer-profiles/123`).reply(400)
-
-    const event = createTestEvent({
-      type: 'identify',
-      event: 'Test Event',
-      userId: externalCustomerId,
-      traits: {
-        name: 'Joe Bob',
-        email,
-        phone,
-        address: '123 Test St. New York City NY US 10001',
-        tier: 'vip'
-      }
-    })
-
-    let response, error
-    try {
-      response = await testDestination.testAction('customer', {
-        event,
-        settings,
-        mapping: {
-          name: { '@path': '$.traits.name' },
-          email: { '@path': '$.traits.email' },
-          phone: { '@path': '$.traits.phone' },
-          externalCustomerId: { '@path': '$.userId' },
-          address: { '@path': '$.traits.address' },
-          customAttributes: { tier: { '@path': '$.traits.tier' } }
-        }
-      })
-    } catch (e) {
-      error = e
-    }
-
-    expect(response).toBeUndefined()
-    expect(error).toBeInstanceOf(HTTPError)
-  })
+  }
 })

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/snapshot.test.ts
@@ -7,6 +7,7 @@ const testDestination = createTestIntegration(destination)
 const actionSlug = 'customer'
 const destinationSlug = 'Gladly'
 const seedName = `${destinationSlug}#${actionSlug}`
+const url = 'https://test-org.us-1.gladly.com'
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
@@ -14,12 +15,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
 
     nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(201)
+    nock(/.*/).persist().patch(/.*/).reply(204)
 
     const event = createTestEvent({
       properties: eventData
     })
+
+    settingsData.url = url
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
@@ -47,12 +50,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
 
     nock(/.*/).persist().get(/.*/).reply(200)
-    nock(/.*/).persist().post(/.*/).reply(200)
-    nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(201)
+    nock(/.*/).persist().patch(/.*/).reply(204)
 
     const event = createTestEvent({
       properties: eventData
     })
+
+    settingsData.url = url
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/snapshot.test.ts
@@ -8,6 +8,7 @@ const actionSlug = 'customer'
 const destinationSlug = 'Gladly'
 const seedName = `${destinationSlug}#${actionSlug}`
 const url = 'https://test-org.us-1.gladly.com'
+const email = 'test@gladly.com'
 
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
@@ -18,11 +19,12 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     nock(/.*/).persist().post(/.*/).reply(201)
     nock(/.*/).persist().patch(/.*/).reply(204)
 
+    eventData.email = email
+    settingsData.url = url
+
     const event = createTestEvent({
       properties: eventData
     })
-
-    settingsData.url = url
 
     const responses = await testDestination.testAction(actionSlug, {
       event: event,

--- a/packages/destination-actions/src/destinations/gladly/customer/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'customer'
+const destinationSlug = 'Gladly'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
@@ -14,10 +14,6 @@ export interface Payload {
    */
   phone?: string
   /**
-   * Customer ID in your system of record.
-   */
-  externalCustomerId: string
-  /**
    * Customer's full address
    */
   address?: string
@@ -27,4 +23,5 @@ export interface Payload {
   customAttributes?: {
     [k: string]: unknown
   }
+  override: boolean
 }

--- a/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
@@ -1,0 +1,24 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Customer's name
+   */
+  name?: string
+  email?: string
+  phone?: string
+  /**
+   * Customer ID in your system of record.
+   */
+  externalCustomerId?: string
+  /**
+   * Customer's full address
+   */
+  address?: string
+  /**
+   * Organization-specific attributes from Customer system of record. The shape of customAttributes is defined by the Customer Profile Definition.
+   */
+  customAttributes?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
@@ -5,7 +5,13 @@ export interface Payload {
    * Customer's name
    */
   name?: string
+  /**
+   * Email address for the customer
+   */
   email?: string
+  /**
+   * Mobile phone number for the customer
+   */
   phone?: string
   /**
    * Customer ID in your system of record.

--- a/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
@@ -16,7 +16,7 @@ export interface Payload {
   /**
    * Customer ID in your system of record.
    */
-  externalCustomerId?: string
+  externalCustomerId: string
   /**
    * Customer's full address
    */

--- a/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * If true, this will override the existing Gladly Customer Profile data only if data is passed from the source
+   */
+  override: boolean
+  /**
    * Customer's name
    */
   name?: string
@@ -10,7 +14,7 @@ export interface Payload {
    */
   email?: string
   /**
-   * Mobile phone number for the customer
+   * Mobile phone number for the customer. Please ensure the number is either entered as is or following the E.164 format
    */
   phone?: string
   /**
@@ -23,5 +27,4 @@ export interface Payload {
   customAttributes?: {
     [k: string]: unknown
   }
-  override: boolean
 }

--- a/packages/destination-actions/src/destinations/gladly/customer/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/index.ts
@@ -8,6 +8,13 @@ const action: ActionDefinition<Settings, Payload> = {
   title: 'Customer',
   description: '',
   fields: {
+    override: {
+      label: 'Override Existing Values?',
+      description:
+        'If true, this will override the existing Gladly Customer Profile data only if data is passed from the source',
+      type: 'boolean',
+      required: true
+    },
     name: {
       label: 'Name',
       description: "Customer's name",
@@ -27,12 +34,6 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Organization-specific attributes from Customer system of record. The shape of customAttributes is defined by the Customer Profile Definition.',
       type: 'object'
-    },
-    override: {
-      label: 'Override Existing Values?',
-      description: '',
-      type: 'boolean',
-      required: true
     }
   },
   perform: async (request, { settings, payload }) => {
@@ -45,7 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (payload.phone) {
       findCustomerResponse = await gladly.findCustomerByPhone(payload.phone)
     } else {
-      throw new IntegrationError('Unable to ')
+      throw new IntegrationError('Please pass either an email or phone number as part of the request', '400', 400)
     }
 
     if (findCustomerResponse.data.length) {

--- a/packages/destination-actions/src/destinations/gladly/customer/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/index.ts
@@ -12,13 +12,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Name',
       description: "Customer's name",
       type: 'string',
-      default: {
-        '@if': {
-          exists: { '@path': '$.traits.name' },
-          then: { '@path': '$.traits.name' },
-          else: { '@path': '$.properties.name' }
-        }
-      }
+      default: { '@path': '$.traits.name' }
     },
     email,
     phone,
@@ -27,13 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Address',
       description: "Customer's full address",
       type: 'string',
-      default: {
-        '@if': {
-          exists: { '@path': '$.traits.address' },
-          then: { '@path': '$.traits.address' },
-          else: { '@path': '$.properties.address' }
-        }
-      }
+      default: { '@path': '$.traits.address' }
     },
     customAttributes: {
       label: 'Custom Attributes',

--- a/packages/destination-actions/src/destinations/gladly/customer/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/customer/index.ts
@@ -1,0 +1,58 @@
+import { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { Gladly } from '../gladly-operations'
+import { email, phone, externalCustomerId } from '../gladly-shared-properties'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Customer',
+  description: '',
+  fields: {
+    name: {
+      label: 'Name',
+      description: "Customer's name",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.name' },
+          then: { '@path': '$.traits.name' },
+          else: { '@path': '$.properties.name' }
+        }
+      }
+    },
+    email,
+    phone,
+    externalCustomerId,
+    address: {
+      label: 'Address',
+      description: "Customer's full address",
+      type: 'string',
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.address' },
+          then: { '@path': '$.traits.address' },
+          else: { '@path': '$.properties.address' }
+        }
+      }
+    },
+    customAttributes: {
+      label: 'Custom Attributes',
+      description:
+        'Organization-specific attributes from Customer system of record. The shape of customAttributes is defined by the Customer Profile Definition.',
+      type: 'object'
+    }
+  },
+  perform: async (request, { settings, payload }) => {
+    const gladly = new Gladly(settings, request)
+
+    const response = await gladly.findCustomer(payload)
+    if (response) {
+      const customer = response.data[0]
+      return await gladly.updateCustomer(customer, payload)
+    } else {
+      return await gladly.createCustomer(payload)
+    }
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gladly/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/generated-types.ts
@@ -1,0 +1,20 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Gladly admin email address
+   */
+  username: string
+  /**
+   * Your Gladly admin api key
+   */
+  password: string
+  /**
+   * Your Gladly Org Name
+   */
+  orgName: string
+  /**
+   * Are you testing with a Gladly UAT environment?
+   */
+  isSandbox: boolean
+}

--- a/packages/destination-actions/src/destinations/gladly/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/generated-types.ts
@@ -10,11 +10,7 @@ export interface Settings {
    */
   password: string
   /**
-   * Your Gladly Org Name
+   * Your Gladly Url
    */
-  orgName: string
-  /**
-   * Are you testing with a Gladly UAT environment?
-   */
-  isSandbox: boolean
+  url: string
 }

--- a/packages/destination-actions/src/destinations/gladly/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Settings {
   /**
-   * Your Gladly admin email address
+   * Your Gladly Admin Email Address
    */
   username: string
   /**
-   * Your Gladly admin api key
+   * Your Gladly Admin API Key
    */
   password: string
   /**
-   * Your Gladly Url
+   * Your Gladly URL
    */
   url: string
 }

--- a/packages/destination-actions/src/destinations/gladly/gladly-mappings.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-mappings.ts
@@ -26,22 +26,18 @@ const generateConversationItemJSON = (payload: CreateConversationItemPayload) =>
 }
 
 const generateCreateCustomerJSON = (payload: CustomerPayload) => {
-  const customerEmails = payload.email ? [{ original: payload.email, primary: false }] : []
-  const customerPhones = payload.phone ? [{ original: payload.phone, primary: false }] : []
-
   return {
-    name: payload.name,
-    address: payload.address,
-    emails: customerEmails,
-    phones: customerPhones,
-    customAttributes: payload.customAttributes
+    ...(payload.name ? { name: payload.name } : {}),
+    ...(payload.address ? { address: payload.address } : {}),
+    ...(payload.email ? { emails: [{ original: payload.email, primary: false }] } : {}),
+    ...(payload.phone ? { phones: [{ original: payload.phone, primary: false }] } : {}),
+    ...(payload.customAttributes ? { customAttributes: payload.customAttributes } : {})
   }
 }
 
 const generateUpdateCustomerJSON = (existingCustomer: Customer, payload: CustomerPayload) => {
-  const overrideExistingValues = payload.override
-
   const customerEmails = existingCustomer.emails || []
+
   if (payload.email) {
     const normalizedEmail = normalizeEmail(payload.email)
     if (!find(customerEmails, { normalized: normalizedEmail }) && !find(customerEmails, { original: payload.email })) {
@@ -50,20 +46,23 @@ const generateUpdateCustomerJSON = (existingCustomer: Customer, payload: Custome
   }
 
   const customerPhones = existingCustomer.phones || []
-  if (payload.phone && !find(existingCustomer.phones, { original: payload.phone })) {
+
+  if (
+    payload.phone &&
+    !find(existingCustomer.phones, { original: payload.phone }) &&
+    !find(existingCustomer.phones, { normalized: payload.phone })
+  ) {
     customerPhones.push({ original: payload.phone, primary: false })
   }
 
-  const customAttributes = overrideExistingValues
-    ? assign(existingCustomer.customAttributes, payload.customAttributes)
-    : existingCustomer.customAttributes
+  const customAttributes = assign(existingCustomer.customAttributes, payload.customAttributes)
 
   return {
-    name: overrideExistingValues && payload.name ? payload.name : existingCustomer.name,
-    address: overrideExistingValues && payload.address ? payload.address : existingCustomer.address,
-    emails: customerEmails,
-    phones: customerPhones,
-    customAttributes
+    ...(payload.override && payload.name ? { name: payload.name } : {}),
+    ...(payload.override && payload.address ? { address: payload.address } : {}),
+    ...(payload.override && payload.email ? { emails: customerEmails } : {}),
+    ...(payload.override && payload.phone ? { phones: customerPhones } : {}),
+    ...(payload.override && payload.customAttributes ? { customAttributes } : {})
   }
 }
 

--- a/packages/destination-actions/src/destinations/gladly/gladly-mappings.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-mappings.ts
@@ -1,0 +1,113 @@
+import isEmpty from 'lodash/isEmpty'
+import find from 'lodash/find'
+import type { GenericPayload, Customer, CustomAttributes, Email, Phone } from './gladly-shared-types'
+
+const generateConversationItemJSON = (payload: GenericPayload) => {
+  const customer = payload.email
+    ? {
+        emailAddress: payload.email
+      }
+    : {
+        mobilePhone: payload.phone
+      }
+  const activityType = payload.email ? 'EMAIL' : 'SMS'
+
+  return {
+    customer,
+    content: {
+      type: 'CUSTOMER_ACTIVITY',
+      title: payload.title,
+      body: payload.body,
+      activityType,
+      sourceName: 'Segment'
+    }
+  }
+}
+
+const generateCreateCustomerJSON = (payload: GenericPayload) => {
+  const name = payload.name ? payload.name : ''
+  const emails = payload.email ? [{ original: payload.email, primary: true }] : []
+  const phones = payload.phone ? [{ original: payload.phone, primary: true }] : []
+  const address = payload.address ? payload.address : ''
+  const externalCustomerId = payload.externalCustomerId ? payload.externalCustomerId : ''
+  const customAttributes = payload.customAttributes ? payload.customAttributes : {}
+
+  return {
+    name,
+    address,
+    emails,
+    phones,
+    externalCustomerId,
+    customAttributes
+  }
+}
+
+const generateUpdateCustomerJSON = (customer: Customer, payload: GenericPayload) => {
+  let name, address, externalCustomerId
+  let emails: Email[] = []
+  let phones: Phone[] = []
+  const customAttributes: CustomAttributes = {}
+
+  if (payload.name) {
+    name = payload.name
+  }
+
+  if (customer.emails) {
+    emails = customer.emails
+  }
+  if (payload.email && customer.emails && !find(customer.emails, { original: payload.email })) {
+    customer.emails.push({ original: payload.email })
+    emails = customer.emails
+  }
+  if (payload.email && isEmpty(customer.emails)) {
+    emails = [{ original: payload.email, primary: true }]
+  }
+
+  if (customer.phones) {
+    phones = customer.phones
+  }
+  if (payload.phone && customer.phones && !find(customer.phones, { original: payload.phone })) {
+    customer.phones.push({ original: payload.phone })
+    phones = customer.phones
+  }
+  if (payload.phone && isEmpty(customer.phones)) {
+    phones = [{ original: payload.phone, primary: true }]
+  }
+
+  if (payload.address) {
+    address = payload.address
+  }
+
+  if (payload.externalCustomerId) {
+    externalCustomerId = payload.externalCustomerId
+  }
+
+  if (!isEmpty(payload.customAttributes) && !isEmpty(customer.customAttributes)) {
+    for (const key in customer.customAttributes) {
+      customAttributes[key] = customer.customAttributes[key]
+    }
+    for (const key in payload.customAttributes) {
+      customAttributes[key] = payload.customAttributes[key]
+    }
+  }
+  if (!isEmpty(payload.customAttributes) && isEmpty(customer.customAttributes)) {
+    for (const key in payload.customAttributes) {
+      customAttributes[key] = payload.customAttributes[key]
+    }
+  }
+
+  return {
+    name: name && name,
+    address: address && address,
+    emails: emails && emails,
+    phones: phones && phones,
+    externalCustomerId: externalCustomerId && externalCustomerId,
+    customAttributes: customAttributes && customAttributes
+  }
+}
+
+export const mappings = {
+  conversationItem: generateConversationItemJSON,
+  createCustomer: generateCreateCustomerJSON,
+  updateCustomer: generateUpdateCustomerJSON
+}

--- a/packages/destination-actions/src/destinations/gladly/gladly-operations.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-operations.ts
@@ -1,7 +1,9 @@
-import { IntegrationError, RequestClient } from '@segment/actions-core'
+import { RequestClient } from '@segment/actions-core'
 import { mappings } from './gladly-mappings'
 import type { Settings } from './generated-types'
-import type { GenericPayload, Customer } from './gladly-shared-types'
+import type { Customer } from './gladly-shared-types'
+import type { Payload as ConversationItemPayload } from './conversationItem/generated-types'
+import type { Payload as CustomerPayload } from './customer/generated-types'
 
 export const API_VERSION = '/api/v1/'
 
@@ -21,85 +23,47 @@ export class Gladly {
     this.request = request
   }
 
-  createConversationItem = async (customerId: string, payload: GenericPayload) => {
-    this.validatePayload(payload)
-
+  createConversationItem = async (customerId: string, payload: ConversationItemPayload) => {
     const resource = resources['createItem'].replace('{id}', customerId)
     const url = this.generateUrl(resource)
     const json = mappings.conversationItem(payload)
 
-    const response = await this.request(url, { method: 'post', json })
-
-    if (!response || response.status !== 200) {
-      throw new IntegrationError('Unable to create customer conversation item')
-    }
-    return response
+    return await this.request(url, { method: 'post', json })
   }
 
-  createCustomer = async (payload: GenericPayload) => {
-    this.validatePayload(payload)
-
+  createCustomer = async (payload: CustomerPayload) => {
     const resource = resources['createCustomer']
     const url = this.generateUrl(resource)
     const json = mappings.createCustomer(payload)
 
-    const response = await this.request(url, { method: 'post', json })
-
-    if (!response || response.status !== 201) {
-      throw new IntegrationError('Unable to create customer profile')
-    }
-    return response
+    return await this.request(url, { method: 'post', json })
   }
 
-  findCustomer = async (payload: GenericPayload) => {
-    this.validatePayload(payload)
+  findCustomerByEmail = async (email: string) => {
+    const param = `email=${encodeURIComponent(email)}`
+    const resource = resources['findCustomer'].replace('{param}', param)
+    const url = this.generateUrl(resource)
 
-    const params = this.generateParams(payload)
-
-    for (const param of params) {
-      const resource = resources['findCustomer'].replace('{param}', param)
-      const url = this.generateUrl(resource)
-
-      const response = await this.request<Customer[]>(url, { method: 'get' })
-
-      if (response && response.data.length) {
-        return response
-      }
-    }
+    return await this.request<Customer[]>(url, { method: 'get' })
   }
 
-  updateCustomer = async (customer: Customer, payload: GenericPayload) => {
-    this.validatePayload(payload)
+  findCustomerByPhone = async (phone: string) => {
+    const param = `phoneNumber=${encodeURIComponent(phone)}`
+    const resource = resources['findCustomer'].replace('{param}', param)
+    const url = this.generateUrl(resource)
 
+    return await this.request<Customer[]>(url, { method: 'get' })
+  }
+
+  updateCustomer = async (customer: Customer, payload: CustomerPayload) => {
     const resource = resources['updateCustomer'].replace('{id}', customer.id)
     const url = this.generateUrl(resource)
     const json = mappings.updateCustomer(customer, payload)
 
-    const response = await this.request(url, { method: 'patch', json })
-
-    if (!response || response.status !== 204) {
-      throw new IntegrationError('Unable to update customer profile')
-    }
-    return response
-  }
-
-  private generateParams = (payload: GenericPayload) => {
-    const params = []
-
-    if (payload.email) params.push(`email=${encodeURIComponent(payload.email)}`)
-    if (payload.phone) params.push(`phoneNumber=${encodeURIComponent(payload.phone)}`)
-    if (payload.externalCustomerId) params.push(`externalCustomerId=${encodeURIComponent(payload.externalCustomerId)}`)
-
-    return params
+    return await this.request(url, { method: 'patch', json })
   }
 
   private generateUrl = (resource: string) => {
     return `${this.url}${API_VERSION}${resource}`
-  }
-
-  private validatePayload = (payload: GenericPayload) => {
-    if (!payload.email && !payload.phone && !payload.externalCustomerId) {
-      throw new IntegrationError('No identifying email, phone or external customer id')
-    }
   }
 }

--- a/packages/destination-actions/src/destinations/gladly/gladly-operations.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-operations.ts
@@ -17,7 +17,7 @@ export class Gladly {
   request: RequestClient
 
   constructor(settings: Settings, request: RequestClient) {
-    this.url = settings.orgName
+    this.url = settings.url
     this.request = request
   }
 

--- a/packages/destination-actions/src/destinations/gladly/gladly-operations.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-operations.ts
@@ -1,0 +1,105 @@
+import { IntegrationError, RequestClient } from '@segment/actions-core'
+import { mappings } from './gladly-mappings'
+import type { Settings } from './generated-types'
+import type { GenericPayload, Customer } from './gladly-shared-types'
+
+export const API_VERSION = '/api/v1/'
+
+const resources = {
+  createItem: 'customers/{id}/conversation-items',
+  createCustomer: 'customer-profiles',
+  findCustomer: 'customer-profiles?{param}',
+  updateCustomer: 'customer-profiles/{id}'
+}
+
+export class Gladly {
+  url: string
+  request: RequestClient
+
+  constructor(settings: Settings, request: RequestClient) {
+    this.url = settings.orgName
+    this.request = request
+  }
+
+  createConversationItem = async (customerId: string, payload: GenericPayload) => {
+    this.validatePayload(payload)
+
+    const resource = resources['createItem'].replace('{id}', customerId)
+    const url = this.generateUrl(resource)
+    const json = mappings.conversationItem(payload)
+
+    const response = await this.request(url, { method: 'post', json })
+
+    if (!response || response.status !== 200) {
+      throw new IntegrationError('Unable to create customer conversation item')
+    }
+    return response
+  }
+
+  createCustomer = async (payload: GenericPayload) => {
+    this.validatePayload(payload)
+
+    const resource = resources['createCustomer']
+    const url = this.generateUrl(resource)
+    const json = mappings.createCustomer(payload)
+
+    const response = await this.request(url, { method: 'post', json })
+
+    if (!response || response.status !== 201) {
+      throw new IntegrationError('Unable to create customer profile')
+    }
+    return response
+  }
+
+  findCustomer = async (payload: GenericPayload) => {
+    this.validatePayload(payload)
+
+    const params = this.generateParams(payload)
+
+    for (const param of params) {
+      const resource = resources['findCustomer'].replace('{param}', param)
+      const url = this.generateUrl(resource)
+
+      const response = await this.request<Customer[]>(url, { method: 'get' })
+
+      if (response && response.data.length) {
+        return response
+      }
+    }
+  }
+
+  updateCustomer = async (customer: Customer, payload: GenericPayload) => {
+    this.validatePayload(payload)
+
+    const resource = resources['updateCustomer'].replace('{id}', customer.id)
+    const url = this.generateUrl(resource)
+    const json = mappings.updateCustomer(customer, payload)
+
+    const response = await this.request(url, { method: 'patch', json })
+
+    if (!response || response.status !== 204) {
+      throw new IntegrationError('Unable to update customer profile')
+    }
+    return response
+  }
+
+  private generateParams = (payload: GenericPayload) => {
+    const params = []
+
+    if (payload.email) params.push(`email=${encodeURIComponent(payload.email)}`)
+    if (payload.phone) params.push(`phoneNumber=${encodeURIComponent(payload.phone)}`)
+    if (payload.externalCustomerId) params.push(`externalCustomerId=${encodeURIComponent(payload.externalCustomerId)}`)
+
+    return params
+  }
+
+  private generateUrl = (resource: string) => {
+    return `${this.url}${API_VERSION}${resource}`
+  }
+
+  private validatePayload = (payload: GenericPayload) => {
+    if (!payload.email && !payload.phone && !payload.externalCustomerId) {
+      throw new IntegrationError('No identifying email, phone or external customer id')
+    }
+  }
+}

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
@@ -9,7 +9,8 @@ export const email: InputField = {
 
 export const phone: InputField = {
   label: 'Phone Number',
-  description: 'Mobile phone number for the customer',
+  description:
+    'Mobile phone number for the customer. Please ensure the number is either entered as is or following the E.164 format',
   type: 'string',
   default: {
     '@if': {

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
@@ -24,5 +24,6 @@ export const externalCustomerId: InputField = {
   label: 'External Customer ID',
   description: 'Customer ID in your system of record.',
   type: 'string',
-  default: { '@path': '$.userId' }
+  default: { '@path': '$.userId' },
+  required: true
 }

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
@@ -19,11 +19,3 @@ export const phone: InputField = {
     }
   }
 }
-
-export const externalCustomerId: InputField = {
-  label: 'External Customer ID',
-  description: 'Customer ID in your system of record.',
-  type: 'string',
-  default: { '@path': '$.userId' },
-  required: true
-}

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-properties.ts
@@ -1,0 +1,28 @@
+import { InputField } from '@segment/actions-core/src/destination-kit/types'
+
+export const email: InputField = {
+  label: 'Email Address',
+  description: 'Email address for the customer',
+  type: 'string',
+  default: { '@path': '$.email' }
+}
+
+export const phone: InputField = {
+  label: 'Phone Number',
+  description: 'Mobile phone number for the customer',
+  type: 'string',
+  default: {
+    '@if': {
+      exists: { '@path': '$.traits.phone' },
+      then: { '@path': '$.traits.phone' },
+      else: { '@path': '$.properties.phone' }
+    }
+  }
+}
+
+export const externalCustomerId: InputField = {
+  label: 'External Customer ID',
+  description: 'Customer ID in your system of record.',
+  type: 'string',
+  default: { '@path': '$.userId' }
+}

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-types.ts
@@ -1,6 +1,3 @@
-import { Payload as CustomerPayload } from './customer/generated-types'
-import { Payload as ConversationItemPayload } from './conversationItem/generated-types'
-
 export type Email = {
   normalized?: string
   original: string
@@ -33,5 +30,3 @@ export type Customer = {
   createdAt: string
   updatedAt?: string
 }
-
-export type GenericPayload = Partial<CustomerPayload & ConversationItemPayload>

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-types.ts
@@ -1,0 +1,37 @@
+import { Payload as CustomerPayload } from './customer/generated-types'
+import { Payload as ConversationItemPayload } from './conversationItem/generated-types'
+
+export type Email = {
+  normalized?: string
+  original: string
+  primary?: boolean
+}
+
+export type Phone = {
+  normalized?: string
+  original: string
+  primary?: boolean
+  regionCode?: string
+  extension?: string
+  smsPreference?: string
+  type?: string
+}
+
+export type CustomAttributes = {
+  [key: string]: any
+}
+
+export type Customer = {
+  name?: string
+  image?: string
+  address?: string
+  emails?: Email[]
+  phones?: Phone[]
+  externalCustomerId?: string
+  customAttributes?: CustomAttributes
+  id: string
+  createdAt: string
+  updatedAt?: string
+}
+
+export type GenericPayload = Partial<CustomerPayload & ConversationItemPayload>

--- a/packages/destination-actions/src/destinations/gladly/gladly-shared-types.ts
+++ b/packages/destination-actions/src/destinations/gladly/gladly-shared-types.ts
@@ -24,7 +24,6 @@ export type Customer = {
   address?: string
   emails?: Email[]
   phones?: Phone[]
-  externalCustomerId?: string
   customAttributes?: CustomAttributes
   id: string
   createdAt: string

--- a/packages/destination-actions/src/destinations/gladly/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/index.ts
@@ -1,9 +1,23 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
-
+import { defaultValues } from '@segment/actions-core'
 import conversationItem from './conversationItem'
-
 import customer from './customer'
+
+const presets: DestinationDefinition['presets'] = [
+  {
+    name: 'Track Calls',
+    subscribe: 'type = "track"',
+    partnerAction: 'trackEvent',
+    mapping: defaultValues(conversationItem.fields)
+  },
+  {
+    name: 'Identify Calls',
+    subscribe: 'type = "identify"',
+    partnerAction: 'identifyUser',
+    mapping: defaultValues(customer.fields)
+  }
+]
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Gladly',
@@ -15,19 +29,19 @@ const destination: DestinationDefinition<Settings> = {
     fields: {
       username: {
         label: 'Admin Email Address',
-        description: 'Your Gladly admin email address',
+        description: 'Your Gladly Admin Email Address',
         type: 'string',
         required: true
       },
       password: {
         label: 'Admin API Key',
-        description: 'Your Gladly admin api key',
+        description: 'Your Gladly Admin API Key',
         type: 'string',
         required: true
       },
       url: {
-        label: 'Gladly Url',
-        description: 'Your Gladly Url',
+        label: 'Gladly URL',
+        description: 'Your Gladly URL',
         type: 'string',
         required: true
       }
@@ -41,6 +55,7 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
 
+  presets,
   actions: {
     conversationItem,
     customer

--- a/packages/destination-actions/src/destinations/gladly/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/index.ts
@@ -28,13 +28,13 @@ const destination: DestinationDefinition<Settings> = {
     scheme: 'basic',
     fields: {
       username: {
-        label: 'Admin Email Address',
+        label: "API User's Email Address",
         description: 'Your Gladly Admin Email Address',
         type: 'string',
         required: true
       },
       password: {
-        label: 'Admin API Key',
+        label: "API User's API Key",
         description: 'Your Gladly Admin API Key',
         type: 'string',
         required: true
@@ -43,6 +43,7 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Gladly URL',
         description: 'Your Gladly URL',
         type: 'string',
+        format: 'uri',
         required: true
       }
     }

--- a/packages/destination-actions/src/destinations/gladly/index.ts
+++ b/packages/destination-actions/src/destinations/gladly/index.ts
@@ -1,0 +1,50 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import conversationItem from './conversationItem'
+
+import customer from './customer'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Gladly',
+  slug: 'actions-gladly',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'basic',
+    fields: {
+      username: {
+        label: 'Admin Email Address',
+        description: 'Your Gladly admin email address',
+        type: 'string',
+        required: true
+      },
+      password: {
+        label: 'Admin API Key',
+        description: 'Your Gladly admin api key',
+        type: 'string',
+        required: true
+      },
+      url: {
+        label: 'Gladly Url',
+        description: 'Your Gladly Url',
+        type: 'string',
+        required: true
+      }
+    }
+  },
+
+  extendRequest({ settings }) {
+    return {
+      username: settings.username,
+      password: settings.password
+    }
+  },
+
+  actions: {
+    conversationItem,
+    customer
+  }
+}
+
+export default destination


### PR DESCRIPTION
## What 
Gladly Destination Action connector for Segment. More details found here -> https://www.notion.so/gladly/Segment-Destination-App-79e6961297744d749c0411d0990838a6

The Gladly Destination Action app allows customers to either create/update a customer profile or update a customer's timeline based off of events that are triggered in Segment. For example, lets say our customer has a source that triggers a track event whenever a customer purchases an item on their website. They could use this app to write that event to the customer's timeline in Gladly. Similarly, if a customer has a Source that triggers whenever a customer updates their profile on the customer's website, they could use this app to automatically update that customer's profile in Gladly.

## Why
We are increasingly seeing Segment as a key platform in our customers and prospects tech stack and this has been a required integration in some key deals.  As CDPs continue to see increased adoption, it makes sense for us to have an integration with the leading CDP platform that we come across most often.

## Testing
- clone the code
- cd into the project
- run `PORT=3000 ./bin/run serve --destination gladly`
- wait for the local ui to pop up (credentials in 1Pass)
- log into gladly
- create an api token
- go back to the local ui
- in user settings ui, add the email, api token and url for the env you're testing
- test using the local ui
- try adding a conversation item to a customer profile using the conversation action
- try creating a customer profile using the customer action
- try updating a customer profile using the customer action

## Notes
Here are the Gladly Destination Settings that are generated from gladly/index.ts
<img width="530" alt="Screen Shot 2022-08-08 at 10 41 03 AM" src="https://user-images.githubusercontent.com/88007603/183457667-86430c10-b698-4234-b3bb-1ac6c2a4397e.png">

